### PR TITLE
fix: 🐛 change the path of module in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module zinx
+module github.com/aceld/zinx
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aceld/zinx
+module github.com/Aberstone/zinx
 
 go 1.13
 


### PR DESCRIPTION
Modify go.mod to fix  module decalres errors when getting packages by using _go get -u github.com/aceld/zinx_