### PR TITLE
修复时间轮无法通过CancelTimer方法删除Timer的bug

### DIFF
--- a/ztimer/timerscheduler_test.go
+++ b/ztimer/timerscheduler_test.go
@@ -10,6 +10,7 @@ package ztimer
 import (
 	"fmt"
 	"github.com/aceld/zinx/zlog"
+	"log"
 	"testing"
 	"time"
 )
@@ -59,6 +60,21 @@ func TestNewAutoExecTimerScheduler(t *testing.T) {
 			break
 		}
 	}
+
+	//阻塞等待
+	select {}
+}
+
+
+//测试取消一个定时器
+func TestCancelTimerScheduler(t *testing.T) {
+	Scheduler := NewAutoExecTimerScheduler()
+	f1 := NewDelayFunc(foo, []interface{}{3,  3})
+	f2 := NewDelayFunc(foo, []interface{}{5,  5})
+	timerId1,_:=Scheduler.CreateTimerAfter(f1, time.Duration(3)*time.Second)
+	timerId2,_:=Scheduler.CreateTimerAfter(f2, time.Duration(5)*time.Second)
+	log.Printf("timerId1=%d ,timerId2=%d\n",timerId1,timerId2)
+	Scheduler.CancelTimer(timerId1)    //删除timerId1
 
 	//阻塞等待
 	select {}


### PR DESCRIPTION
附上测试代码：
```

var Scheduler *ztimer.TimerScheduler

func init() {
	Scheduler = ztimer.NewAutoExecTimerScheduler()
}

```

```
f1 := ztimer.NewDelayFunc(func(v ...interface{}) {
	log.Println("aaaaaa")
}, []interface{}{})
f2 := ztimer.NewDelayFunc(func(v ...interface{}) {
	log.Println("bbbbbb")
}, []interface{}{})
timerId1,_:=Scheduler.CreateTimerAfter(f1, time.Duration(3)*time.Second)
timerId2,_:=Scheduler.CreateTimerAfter(f2, time.Duration(5)*time.Second)
log.Printf("timerId=%d ,timerId2=%d\n",timerId1,timerId2)
Scheduler.CancelTimer(timerId1)    //删除timerId1
```

预期结果：5秒后打印bbbbbb
实际结果：3秒后打印aaaaaa，5秒后打印bbbbbb


该问题已修复