### PR TITLE
fix nil pointer check for player

### DIFF
--- a/zinx_app_demo/mmo_game/server.go
+++ b/zinx_app_demo/mmo_game/server.go
@@ -41,7 +41,7 @@ func OnConnectionLost(conn ziface.IConnection) {
 	player := core.WorldMgrObj.GetPlayerByPID(pID.(int32))
 
 	//触发玩家下线业务
-	if pID != nil {
+	if player != nil {
 		player.LostConnection()
 	}
 


### PR DESCRIPTION
Instead of checking nil pointer for pID,  player should be checked before call its method