### PR TITLE
修复死锁问题

### DIFF
--- a/znet/server_test.go
+++ b/znet/server_test.go
@@ -161,3 +161,16 @@ func TestServer(t *testing.T) {
 		return
 	}
 }
+
+func TestServerDeadLock(t *testing.T) {
+	s := NewServer()
+
+	s.Start()
+	time.Sleep(time.Second * 1)
+
+	go func() {
+		_, _ = net.Dial("tcp", "127.0.0.1:8999")
+	}()
+	time.Sleep(time.Second * 1)
+	s.Stop()
+}


### PR DESCRIPTION
Stop()方法改为仅仅cancel context，经观察，Start()使用时是go start()，但本身此方法又不是阻塞方法，那干脆不要浪费这个协程，在Start()的最后阻塞等待被cancel,在被cancel后执行释放资源逻辑 #129 