### PR TITLE
fix: msgBuffChan加上超时判断，在网络阻塞和超时情况下不会阻塞服务。网络恢复后，服务继续运行

### DIFF
--- a/zinx_app_demo/mmo_game/server.go
+++ b/zinx_app_demo/mmo_game/server.go
@@ -36,16 +36,20 @@ func OnConnecionAdd(conn ziface.IConnection) {
 func OnConnectionLost(conn ziface.IConnection) {
 	//获取当前连接的PID属性
 	pID, _ := conn.GetProperty("pID")
+	var playerID int32
+	if pID != nil{
+		playerID = pID.(int32)
+	}
 
 	//根据pID获取对应的玩家对象
-	player := core.WorldMgrObj.GetPlayerByPID(pID.(int32))
+		player := core.WorldMgrObj.GetPlayerByPID(playerID)
 
 	//触发玩家下线业务
 	if player != nil {
 		player.LostConnection()
 	}
 
-	fmt.Println("====> Player ", pID, " left =====")
+	fmt.Println("====> Player ", playerID, " left =====")
 
 }
 


### PR DESCRIPTION
测试时，远程服务器网络带宽打满时，缓冲队列没有超时机制，卡死挂起，导致主程序挂起。带宽恢复后，server 也不能提供连接服务。 增加超时机制后，即时遇到超时和带宽打满情况，也可正常运行。