### PR TITLE
修复sendMsg与Close并发运行时可能出现的死锁bug

### DIFF
--- a/znet/connection.go
+++ b/znet/connection.go
@@ -25,8 +25,6 @@ type Connection struct {
 	//告知该链接已经退出/停止的channel
 	ctx    context.Context
 	cancel context.CancelFunc
-	//无缓冲管道，用于读、写两个goroutine之间的消息通信
-	msgChan chan []byte
 	//有缓冲管道，用于读、写两个goroutine之间的消息通信
 	msgBuffChan chan []byte
 
@@ -48,7 +46,6 @@ func NewConnection(server ziface.IServer, conn *net.TCPConn, connID uint32, msgH
 		ConnID:      connID,
 		isClosed:    false,
 		MsgHandler:  msgHandler,
-		msgChan:     make(chan []byte),
 		msgBuffChan: make(chan []byte, utils.GlobalObject.MaxMsgChanLen),
 		property:    nil,
 	}
@@ -65,13 +62,6 @@ func (c *Connection) StartWriter() {
 
 	for {
 		select {
-		case data := <-c.msgChan:
-			//有数据要写给客户端
-			if _, err := c.Conn.Write(data); err != nil {
-				fmt.Println("Send Data error:, ", err, " Conn Writer exit")
-				return
-			}
-			//fmt.Printf("Send data succ! data = %+v\n", data)
 		case data, ok := <-c.msgBuffChan:
 			if ok {
 				//有数据要写给客户端
@@ -199,9 +189,8 @@ func (c *Connection) SendMsg(msgID uint32, data []byte) error {
 	}
 
 	//写回客户端
-	c.msgChan <- msg
-
-	return nil
+	_, err = c.Conn.Write(msg)
+	return err
 }
 
 //SendBuffMsg  发生BuffMsg

--- a/znet/server_test.go
+++ b/znet/server_test.go
@@ -192,11 +192,9 @@ func (d *DemoPacket) Pack(msg ziface.IMessage) ([]byte, error) {
 func (br *CloseConnectionBeforeSendMsgRouter) Handle(req ziface.IRequest) {
 	connection := req.GetConnection()
 
-	dp := &DemoPacket{}
 	msg := "Zinx server response message for CloseConnectionBeforeSendMsgRouter"
-	pack, _ := dp.Pack(NewMsgPackage(0, []byte(msg)))
 	connection.Stop()
-	_ = connection.SendMsg(1, pack)
+	_ = connection.SendMsg(1, []byte(msg))
 	fmt.Println("send: ", msg)
 }
 
@@ -217,8 +215,8 @@ func TestCloseConnectionBeforeSendMsg(t *testing.T) {
 		_, _ = conn.Write(pack)
 		fmt.Println("send: ", msg)
 		buffer := make([]byte, 1024)
-		read, _ := conn.Read(buffer)
-		fmt.Println("receive: ", string(buffer[:read]))
+		readLen, _ := conn.Read(buffer)
+		fmt.Println("received all data: ", string(buffer[dp.GetHeadLen():readLen]))
 		wg.Done()
 	}()
 	wg.Wait()

--- a/znet/server_test.go
+++ b/znet/server_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -172,5 +173,54 @@ func TestServerDeadLock(t *testing.T) {
 		_, _ = net.Dial("tcp", "127.0.0.1:8999")
 	}()
 	time.Sleep(time.Second * 1)
+	s.Stop()
+}
+
+type CloseConnectionBeforeSendMsgRouter struct {
+	BaseRouter
+}
+
+type DemoPacket struct {
+	DataPack
+}
+
+func (d *DemoPacket) Pack(msg ziface.IMessage) ([]byte, error) {
+	time.Sleep(time.Second * 1)
+	return d.DataPack.Pack(msg)
+}
+
+func (br *CloseConnectionBeforeSendMsgRouter) Handle(req ziface.IRequest) {
+	connection := req.GetConnection()
+
+	dp := &DemoPacket{}
+	msg := "Zinx server response message for CloseConnectionBeforeSendMsgRouter"
+	pack, _ := dp.Pack(NewMsgPackage(0, []byte(msg)))
+	connection.Stop()
+	_ = connection.SendMsg(1, pack)
+	fmt.Println("send: ", msg)
+}
+
+func TestCloseConnectionBeforeSendMsg(t *testing.T) {
+	s := NewServer()
+	s.AddRouter(1, &CloseConnectionBeforeSendMsgRouter{})
+
+	s.Start()
+	time.Sleep(time.Second * 1)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		conn, _ := net.Dial("tcp", "127.0.0.1:8999")
+		dp := NewDataPack()
+		msg := "Zinx client request message for CloseConnectionBeforeSendMsgRouter"
+		pack, _ := dp.Pack(NewMsgPackage(1, []byte(msg)))
+		_, _ = conn.Write(pack)
+		fmt.Println("send: ", msg)
+		buffer := make([]byte, 1024)
+		read, _ := conn.Read(buffer)
+		fmt.Println("receive: ", string(buffer[:read]))
+		wg.Done()
+	}()
+	wg.Wait()
 	s.Stop()
 }


### PR DESCRIPTION
修复sendMsg与Close并发运行时可能出现的死锁bug #134 
采用直接write写的方式，用channel后并并能使sendMessage方法能同步运行，而且多了一个channel开销，并因此引出bug，所以就干脆将这个channel删了，直接使用write发送。
这样改还有一个好处，就是能正常返回write的错误信息，避免成功调用此方法，但信息由于对方关闭连接等原因没有实际发送的尴尬bug(之前虽然打日志了，但代码中无法感知，也就没法做异常判断流程)