### PR TITLE
更改CallOnConnStart函数执行位置

### DIFF
--- a/znet/connection.go
+++ b/znet/connection.go
@@ -140,12 +140,12 @@ func (c *Connection) StartReader() {
 //Start 启动连接，让当前连接开始工作
 func (c *Connection) Start() {
 	c.ctx, c.cancel = context.WithCancel(context.Background())
+	//按照用户传递进来的创建连接时需要处理的业务，执行钩子方法
+	c.TCPServer.CallOnConnStart(c)
 	//1 开启用户从客户端读取数据流程的Goroutine
 	go c.StartReader()
 	//2 开启用于写回客户端数据流程的Goroutine
 	go c.StartWriter()
-	//按照用户传递进来的创建连接时需要处理的业务，执行钩子方法
-	c.TCPServer.CallOnConnStart(c)
 
 	select {
 	case <-c.ctx.Done():


### PR DESCRIPTION
- 描述：
  - CallOnConnStart 函数后于 `go c.StartReader() `go c.StartWriter()` 执行，会导致本该在连接初始化执行的逻辑后于请求执行（reader goroutine，writer goroutine），导致逻辑顺序错乱 
- 产生场景：
  - 服务器压测
- 触发环境：
  - 多核并发情况下，runtime.GOMAXPROCS > 1