### PR TITLE
修改了原本的路由方式，新加入用户自定义配置类

### DIFF
--- a/examples/Zinx_NewRouter/Client.go
+++ b/examples/Zinx_NewRouter/Client.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/zpack"
+	"io"
+	"net"
+	"time"
+)
+
+//模拟客户端
+func main() {
+
+	fmt.Println("Client Test ... start")
+	//3秒之后发起测试请求，给服务端开启服务的机会
+	time.Sleep(3 * time.Second)
+
+	conn, err := net.Dial("tcp", "127.0.0.1:8999")
+	if err != nil {
+		fmt.Println("client start err, exit!")
+		return
+	}
+
+	dp := zpack.Factory().NewPack(ziface.ZinxDataPack)
+	msg, _ := dp.Pack(zpack.NewMsgPackage(1, []byte("client test message")))
+	_, err = conn.Write(msg)
+	if err != nil {
+		fmt.Println("client write err: ", err)
+		return
+	}
+
+	for i := 0; i < 4; i++ {
+		//先读出流中的head部分
+		headData := make([]byte, dp.GetHeadLen())
+		_, err = io.ReadFull(conn, headData)
+		if err != nil {
+			fmt.Println("client read head err: ", err)
+			return
+		}
+
+		// 将headData字节流 拆包到msg中
+		msgHead, err := dp.Unpack(headData)
+		if err != nil {
+			fmt.Println("client unpack head err: ", err)
+			return
+		}
+
+		if msgHead.GetDataLen() > 0 {
+			//msg 是有data数据的，需要再次读取data数据
+			msg := msgHead.(*zpack.Message)
+			msg.Data = make([]byte, msg.GetDataLen())
+
+			//根据dataLen从io中读取字节流
+			_, err := io.ReadFull(conn, msg.Data)
+			if err != nil {
+				fmt.Println("client unpack data err")
+				return
+			}
+
+			fmt.Printf("==> Client receive Msg: ID = %d, len = %d , data = %s\n", msg.ID, msg.DataLen, msg.Data)
+		}
+
+	}
+
+	time.Sleep(time.Second)
+}

--- a/examples/Zinx_NewRouter/Server.go
+++ b/examples/Zinx_NewRouter/Server.go
@@ -16,6 +16,7 @@ func Handle1(router ziface.IRouter, req ziface.IRequest) {
 
 // test handleRouter
 func Handle2(router ziface.IRouter, req ziface.IRequest) {
+	router.Next(req)
 	fmt.Println("2")
 	if err := req.GetConnection().SendMsg(0, []byte("test2")); err != nil {
 		fmt.Println(err)
@@ -25,6 +26,7 @@ func Handle2(router ziface.IRouter, req ziface.IRequest) {
 // test handleRouter
 func Handle3(router ziface.IRouter, req ziface.IRequest) {
 	fmt.Println("3")
+	router.Abort()
 	if err := req.GetConnection().SendMsg(0, []byte("test3")); err != nil {
 		fmt.Println(err)
 	}

--- a/examples/Zinx_NewRouter/Server.go
+++ b/examples/Zinx_NewRouter/Server.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/znet"
+)
+
+// test handleRouter
+func Handle1(router ziface.IRouter, req ziface.IRequest) {
+	fmt.Println("1")
+	if err := req.GetConnection().SendMsg(0, []byte("test1")); err != nil {
+		fmt.Println(err)
+	}
+}
+
+// test handleRouter
+func Handle2(router ziface.IRouter, req ziface.IRequest) {
+	fmt.Println("2")
+	if err := req.GetConnection().SendMsg(0, []byte("test2")); err != nil {
+		fmt.Println(err)
+	}
+}
+
+// test handleRouter
+func Handle3(router ziface.IRouter, req ziface.IRequest) {
+	fmt.Println("3")
+	if err := req.GetConnection().SendMsg(0, []byte("test3")); err != nil {
+		fmt.Println(err)
+	}
+}
+
+// test handleRouter
+func Handle4(router ziface.IRouter, req ziface.IRequest) {
+	fmt.Println("4")
+	if err := req.GetConnection().SendMsg(0, []byte("test4")); err != nil {
+		fmt.Println(err)
+	}
+
+}
+
+func main() {
+	s := znet.NewServer()
+	s.AddRouter(1, Handle1, Handle2, Handle3, Handle4)
+
+	s.Serve()
+}

--- a/examples/Zinx_NewRouter/conf/zinx.json
+++ b/examples/Zinx_NewRouter/conf/zinx.json
@@ -1,0 +1,9 @@
+{
+  "Name":"zinx server Demo",
+  "Host":"127.0.0.1",
+  "TcpPort":8999,
+  "MaxConn":3,
+  "WorkerPoolSize":10,
+  "LogDir": "./mylog",
+  "LogFile":"zinx.log"
+}

--- a/utils/UserConf.go
+++ b/utils/UserConf.go
@@ -1,0 +1,40 @@
+package utils
+
+import "github.com/aceld/zinx/ziface"
+
+/*
+	存储一切有关Zinx框架的全局参数，供其他模块使用
+	一些参数也可以通过 用户根据 zinx.json来配置
+*/
+type UserConf struct {
+	/*
+		Server
+	*/
+	TCPServer  ziface.IServer //当前Zinx的全局Server对象
+	Host       string         //当前服务器主机IP
+	TCPPort    int            //当前服务器主机监听端口号
+	Name       string         //当前服务器名称
+	TCPVersion string         //链接的版本号
+
+	/*
+		Zinx
+	*/
+	Version          string //当前Zinx版本号
+	MaxPacketSize    uint32 //都需数据包的最大值
+	MaxConn          int    //当前服务器主机允许的最大链接个数
+	WorkerPoolSize   uint32 //业务工作Worker池的数量
+	MaxWorkerTaskLen uint32 //业务工作Worker对应负责的任务队列最大任务存储数量
+	MaxMsgChanLen    uint32 //SendBuffMsg发送消息的缓冲最大长度
+
+	/*
+		config file path
+	*/
+	ConfFilePath string
+
+	/*
+		logger
+	*/
+	LogDir        string //日志所在文件夹 默认"./log"
+	LogFile       string //日志文件名称   默认""  --如果没有设置日志文件，打印信息将打印至stderr
+	LogDebugClose bool   //是否关闭Debug日志级别调试信息 默认false  -- 默认打开debug信息
+}

--- a/ziface/imsghandler.go
+++ b/ziface/imsghandler.go
@@ -17,8 +17,9 @@ package ziface
 	消息管理抽象层
 */
 type IMsgHandle interface {
-	DoMsgHandler(request IRequest)          //马上以非阻塞方式处理消息
-	AddRouter(msgID uint32, router IRouter) //为消息添加具体的处理逻辑
-	StartWorkerPool()                       //启动worker工作池
-	SendMsgToTaskQueue(request IRequest)    //将消息交给TaskQueue,由worker进行处理
+	DoMsgHandler(request IRequest) //马上以非阻塞方式处理消息
+	//AddRouter(msgID uint32, router IRouter) //为消息添加具体的处理逻辑
+	AddRouter(msgId uint32, handler ...RouterHandler)
+	StartWorkerPool()                    //启动worker工作池
+	SendMsgToTaskQueue(request IRequest) //将消息交给TaskQueue,由worker进行处理
 }

--- a/ziface/irouter.go
+++ b/ziface/irouter.go
@@ -17,8 +17,19 @@ package ziface
 	路由接口， 这里面路由是 使用框架者给该链接自定的 处理业务方法
 	路由里的IRequest 则包含用该链接的链接信息和该链接的请求数据信息
 */
+//type IRouter interface {
+//	PreHandle(request IRequest)  //在处理conn业务之前的钩子方法
+//	Handle(request IRequest)     //处理conn业务的方法
+//	PostHandle(request IRequest) //处理conn业务之后的钩子方法
+//}
+
+//仿gin框架路由处理
+type RouterHandler func(router IRouter, request IRequest)
 type IRouter interface {
-	PreHandle(request IRequest)  //在处理conn业务之前的钩子方法
-	Handle(request IRequest)     //处理conn业务的方法
-	PostHandle(request IRequest) //处理conn业务之后的钩子方法
+	//执行下一个函数
+	Next(request IRequest)
+	//终结路由函数的执行
+	Abort()
+	//是否终结了函数
+	IsAbort() bool
 }

--- a/ziface/iserver.go
+++ b/ziface/iserver.go
@@ -15,14 +15,15 @@ package ziface
 
 //定义服务接口
 type IServer interface {
-	Start()		//启动服务器方法
-	Stop() 		//停止服务器方法
-	Serve() 	//开启业务服务方法
-	AddRouter(msgID uint32, router IRouter) //路由功能：给当前服务注册一个路由业务方法，供客户端链接处理使用
-	GetConnMgr() IConnManager 				//得到链接管理
-	SetOnConnStart(func(IConnection)) 		//设置该Server的连接创建时Hook函数
-	SetOnConnStop(func(IConnection)) 		//设置该Server的连接断开时的Hook函数
-	CallOnConnStart(conn IConnection) 		//调用连接OnConnStart Hook函数
-	CallOnConnStop(conn IConnection) 		//调用连接OnConnStop Hook函数
+	Start() //启动服务器方法
+	Stop()  //停止服务器方法
+	Serve() //开启业务服务方法
+	//AddRouter(msgID uint32, router IRouter) //路由功能：给当前服务注册一个路由业务方法，供客户端链接处理使用
+	AddRouter(msgid uint32, router ...RouterHandler)
+	GetConnMgr() IConnManager         //得到链接管理
+	SetOnConnStart(func(IConnection)) //设置该Server的连接创建时Hook函数
+	SetOnConnStop(func(IConnection))  //设置该Server的连接断开时的Hook函数
+	CallOnConnStart(conn IConnection) //调用连接OnConnStart Hook函数
+	CallOnConnStop(conn IConnection)  //调用连接OnConnStop Hook函数
 	Packet() IDataPack
 }

--- a/znet/msghandler.go
+++ b/znet/msghandler.go
@@ -9,19 +9,33 @@ import (
 )
 
 // MsgHandle -
+//type MsgHandle struct {
+//	Apis           map[uint32]ziface.IRouter //存放每个MsgID 所对应的处理方法的map属性
+//	WorkerPoolSize uint32                    //业务工作Worker池的数量
+//	TaskQueue      []chan ziface.IRequest    //Worker负责取任务的消息队列
+//}
+//
+////NewMsgHandle 创建MsgHandle
+//func NewMsgHandle() *MsgHandle {
+//	return &MsgHandle{
+//		Apis:           make(map[uint32]ziface.IRouter),
+//		WorkerPoolSize: utils.GlobalObject.WorkerPoolSize,
+//		//一个worker对应一个queue
+//		TaskQueue: make([]chan ziface.IRequest, utils.GlobalObject.WorkerPoolSize),
+//	}
+//}
+
 type MsgHandle struct {
-	Apis           map[uint32]ziface.IRouter //存放每个MsgID 所对应的处理方法的map属性
-	WorkerPoolSize uint32                    //业务工作Worker池的数量
-	TaskQueue      []chan ziface.IRequest    //Worker负责取任务的消息队列
+	Apis           map[uint32]*Router     //存放每个MsgID 所对应的处理方法的切片
+	WorkerPoolSize uint32                 //业务工作Worker池的数量
+	TaskQueue      []chan ziface.IRequest //Worker负责取任务的消息队列
 }
 
-//NewMsgHandle 创建MsgHandle
 func NewMsgHandle() *MsgHandle {
 	return &MsgHandle{
-		Apis:           make(map[uint32]ziface.IRouter),
+		Apis:           make(map[uint32]*Router),
 		WorkerPoolSize: utils.GlobalObject.WorkerPoolSize,
-		//一个worker对应一个queue
-		TaskQueue: make([]chan ziface.IRequest, utils.GlobalObject.WorkerPoolSize),
+		TaskQueue:      make([]chan ziface.IRequest, utils.GlobalObject.WorkerPoolSize), //一个消息队列对应一个worker池子
 	}
 }
 
@@ -37,29 +51,53 @@ func (mh *MsgHandle) SendMsgToTaskQueue(request ziface.IRequest) {
 	mh.TaskQueue[workerID] <- request
 }
 
-//DoMsgHandler 马上以非阻塞方式处理消息
-func (mh *MsgHandle) DoMsgHandler(request ziface.IRequest) {
-	handler, ok := mh.Apis[request.GetMsgID()]
+//
+////DoMsgHandler 马上以非阻塞方式处理消息
+//func (mh *MsgHandle) DoMsgHandler(request ziface.IRequest) {
+//	handler, ok := mh.Apis[request.GetMsgID()]
+//	if !ok {
+//		fmt.Println("api msgID = ", request.GetMsgID(), " is not FOUND!")
+//		return
+//	}
+//
+//	//执行对应处理方法
+//	handler.PreHandle(request)
+//	handler.Handle(request)
+//	handler.PostHandle(request)
+//}
+//
+////AddRouter 为消息添加具体的处理逻辑
+//func (mh *MsgHandle) AddRouter(msgID uint32, router ziface.IRouter) {
+//	//1 判断当前msg绑定的API处理方法是否已经存在
+//	if _, ok := mh.Apis[msgID]; ok {
+//		panic("repeated api , msgID = " + strconv.Itoa(int(msgID)))
+//	}
+//	//2 添加msg与api的绑定关系
+//	mh.Apis[msgID] = router
+//	fmt.Println("Add api msgID = ", msgID)
+//}
+
+func (m *MsgHandle) DoMsgHandler(request ziface.IRequest) {
+	router, ok := m.Apis[request.GetMsgID()]
 	if !ok {
-		fmt.Println("api msgID = ", request.GetMsgID(), " is not FOUND!")
+		fmt.Println("not find Router In Apis")
 		return
 	}
-
-	//执行对应处理方法
-	handler.PreHandle(request)
-	handler.Handle(request)
-	handler.PostHandle(request)
+	router.Reindx()
+	router.Next(request)
 }
 
-//AddRouter 为消息添加具体的处理逻辑
-func (mh *MsgHandle) AddRouter(msgID uint32, router ziface.IRouter) {
+func (m *MsgHandle) AddRouter(msgId uint32, handler ...ziface.RouterHandler) {
 	//1 判断当前msg绑定的API处理方法是否已经存在
-	if _, ok := mh.Apis[msgID]; ok {
-		panic("repeated api , msgID = " + strconv.Itoa(int(msgID)))
+	if _, ok := m.Apis[msgId]; ok {
+		panic("repeated api , msgId = " + strconv.Itoa(int(msgId)))
 	}
+
 	//2 添加msg与api的绑定关系
-	mh.Apis[msgID] = router
-	fmt.Println("Add api msgID = ", msgID)
+	m.Apis[msgId] = &Router{}
+	m.Apis[msgId].Reset()
+	m.Apis[msgId].AddHandler(handler...)
+	fmt.Println("Add api msgId = ", msgId)
 }
 
 //StartOneWorker 启动一个Worker工作流程

--- a/znet/router.go
+++ b/znet/router.go
@@ -3,17 +3,50 @@ package znet
 import "github.com/aceld/zinx/ziface"
 
 //BaseRouter 实现router时，先嵌入这个基类，然后根据需要对这个基类的方法进行重写
-type BaseRouter struct{}
+//type BaseRouter struct{}
 
 //这里之所以BaseRouter的方法都为空，
 // 是因为有的Router不希望有PreHandle或PostHandle
 // 所以Router全部继承BaseRouter的好处是，不需要实现PreHandle和PostHandle也可以实例化
 
-//PreHandle -
-func (br *BaseRouter) PreHandle(req ziface.IRequest) {}
+////PreHandle -
+//func (br *BaseRouter) PreHandle(req ziface.IRequest) {}
+//
+////Handle -
+//func (br *BaseRouter) Handle(req ziface.IRequest) {}
+//
+////PostHandle -
+//func (br *BaseRouter) PostHandle(req ziface.IRequest) {}
 
-//Handle -
-func (br *BaseRouter) Handle(req ziface.IRequest) {}
+type Router struct {
+	index    int8 //函数索引
+	handlers []ziface.RouterHandler
+}
 
-//PostHandle -
-func (br *BaseRouter) PostHandle(req ziface.IRequest) {}
+func (r *Router) Next(request ziface.IRequest) {
+	r.index++
+	for r.index < int8(len(r.handlers)) {
+		r.handlers[r.index](r, request)
+		r.index++
+	}
+}
+
+func (r *Router) Abort() {
+	r.index = int8(len(r.handlers))
+}
+
+func (r *Router) IsAbort() bool {
+	return r.index >= int8(len(r.handlers))
+}
+
+func (r *Router) Reset() {
+	r.index = -1
+	r.handlers = make([]ziface.RouterHandler, 0, 1)
+}
+
+func (r *Router) Reindx() {
+	r.index = -1
+}
+func (r *Router) AddHandler(handler ...ziface.RouterHandler) {
+	r.handlers = append(r.handlers, handler...)
+}

--- a/znet/server.go
+++ b/znet/server.go
@@ -68,6 +68,27 @@ func NewServer(opts ...Option) ziface.IServer {
 	return s
 }
 
+func NewUserConfServer(config *utils.UserConf, opts ...Option) ziface.IServer {
+	//打印logo
+	printLogo()
+
+	s := &Server{
+		Name:       config.Name,
+		IPVersion:  config.TCPVersion,
+		IP:         config.Host,
+		Port:       config.TCPPort,
+		msgHandler: NewMsgHandle(),
+		ConnMgr:    NewConnManager(),
+		exitChan:   nil,
+		packet:     zpack.Factory().NewPack(ziface.ZinxDataPack),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
 //============== 实现 ziface.IServer 里的全部接口方法 ========
 
 //Start 开启网络服务

--- a/znet/server.go
+++ b/znet/server.go
@@ -162,8 +162,11 @@ func (s *Server) Serve() {
 }
 
 //AddRouter 路由功能：给当前服务注册一个路由业务方法，供客户端链接处理使用
-func (s *Server) AddRouter(msgID uint32, router ziface.IRouter) {
-	s.msgHandler.AddRouter(msgID, router)
+//func (s *Server) AddRouter(msgID uint32, router ziface.IRouter) {
+//	s.msgHandler.AddRouter(msgID, router)
+//}
+func (s *Server) AddRouter(msgId uint32, router ...ziface.RouterHandler) {
+	s.msgHandler.AddRouter(msgId, router...)
 }
 
 //GetConnMgr 得到链接管理


### PR DESCRIPTION
原本的路由 prehandle handle PostHandle 三者只是依顺序执行无关联且每个路由都需要用户自己构建路由结构体，这个pr修改成路由为传入指定函数的形式 用Next Abort 来操作顺序，用户也不再需要每一个路由都创建结构体实例，只需要传入指定类型的函数即可，示例如examples/Zinx_NewRouter
新增了一个配置类和新的Server构建方法，用于用户配置注入到配置类来定制参数