### PR TITLE
新增用户配置类，优化原本的路由方式

### DIFF
--- a/examples/zinx_NewRouter/Client.go
+++ b/examples/zinx_NewRouter/Client.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/zpack"
+	"io"
+	"net"
+	"time"
+)
+
+//模拟客户端
+func main() {
+
+	fmt.Println("Client Test ... start")
+	//3秒之后发起测试请求，给服务端开启服务的机会
+	time.Sleep(3 * time.Second)
+
+	conn, err := net.Dial("tcp", "127.0.0.1:8999")
+	if err != nil {
+		fmt.Println("client start err, exit!")
+		return
+	}
+
+	dp := zpack.Factory().NewPack(ziface.ZinxDataPack)
+	msg, _ := dp.Pack(zpack.NewMsgPackage(1, []byte("client test message")))
+	_, err = conn.Write(msg)
+	if err != nil {
+		fmt.Println("client write err: ", err)
+		return
+	}
+
+	for i := 0; i < 3; i++ {
+		//先读出流中的head部分
+		headData := make([]byte, dp.GetHeadLen())
+		_, err = io.ReadFull(conn, headData)
+		if err != nil {
+			fmt.Println("client read head err: ", err)
+			return
+		}
+
+		// 将headData字节流 拆包到msg中
+		msgHead, err := dp.Unpack(headData)
+		if err != nil {
+			fmt.Println("client unpack head err: ", err)
+			return
+		}
+
+		if msgHead.GetDataLen() > 0 {
+			//msg 是有data数据的，需要再次读取data数据
+			msg := msgHead.(*zpack.Message)
+			msg.Data = make([]byte, msg.GetDataLen())
+
+			//根据dataLen从io中读取字节流
+			_, err := io.ReadFull(conn, msg.Data)
+			if err != nil {
+				fmt.Println("client unpack data err")
+				return
+			}
+
+			fmt.Printf("==> Client receive Msg: ID = %d, len = %d , data = %s\n", msg.ID, msg.DataLen, msg.Data)
+		}
+
+	}
+
+	time.Sleep(time.Second)
+}

--- a/examples/zinx_NewRouter/Server.go
+++ b/examples/zinx_NewRouter/Server.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/znet"
+	"time"
+)
+
+type TestRouter struct {
+	znet.BaseRouter
+}
+
+//PreHandle -
+func (t *TestRouter) PreHandle(req ziface.IRequest) {
+	//使用场景模拟  完整路由计时
+	start := time.Now()
+	req.Next()
+
+	fmt.Println("1")
+	if err := req.GetConnection().SendMsg(0, []byte("test1")); err != nil {
+		fmt.Println(err)
+	}
+	elapsed := time.Since(start)
+	fmt.Println("该路由组执行完成耗时：", elapsed)
+}
+
+//Handle -
+func (t *TestRouter) Handle(req ziface.IRequest) {
+	fmt.Println("2")
+
+	//模拟场景2 出现意料之中的错误 如权限不对或者信息错误 则停止后续函数执行，但是次函数会执行完毕
+	if err := Err(); err != nil {
+		req.Abort()
+		fmt.Println("权限不足")
+	}
+
+	if err := req.GetConnection().SendMsg(0, []byte("test2")); err != nil {
+		fmt.Println(err)
+	}
+
+	time.Sleep(1 * time.Millisecond) //模拟函数计时
+}
+
+//PostHandle -
+func (t *TestRouter) PostHandle(req ziface.IRequest) {
+	fmt.Println("3")
+	if err := req.GetConnection().SendMsg(0, []byte("test3")); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func Err() error {
+	//具体业务操作
+
+	return errors.New("Test")
+}
+
+func main() {
+	s := znet.NewServer()
+	s.AddRouter(1, &TestRouter{})
+	s.Serve()
+}

--- a/examples/zinx_NewRouter/conf/zinx.json
+++ b/examples/zinx_NewRouter/conf/zinx.json
@@ -1,0 +1,9 @@
+{
+  "Name":"zinx v-0.10 demoApp",
+  "Host":"127.0.0.1",
+  "TcpPort":7777,
+  "MaxConn":3,
+  "WorkerPoolSize":10,
+  "LogDir": "./mylog",
+  "LogFile":"zinx.log"
+}

--- a/utils/UserConf.go
+++ b/utils/UserConf.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"github.com/aceld/zinx/ziface"
+)
+
+type Config struct {
+
+	//Server
+	TcpServer  ziface.IServer //当前全局的Server对象
+	Host       string         //当前服务器主机监听的IP
+	TcpPort    int            //当前服务器监听的端口
+	Name       string         //当前服务器的名称
+	TcpVersion string         //tcp版本
+
+	//服务器可选配置
+	Version          string //版本
+	MaxConn          int    //最大连接数量
+	MaxPacketSize    uint32 //当前框架数据包的最大尺寸
+	WorkerPoolSize   uint32 //业务工作Worker池的数量
+	MaxWorkerTaskLen uint32 //业务工作Worker对应负责的任务队列最大任务存储数量
+	MaxMsgChanLen    uint32 //SendBuffMsg发送消息的缓冲最大长度
+
+	/*
+		logger
+	*/
+	LogDir        string //日志所在文件夹 默认"./log"
+	LogFile       string //日志文件名称   默认""  --如果没有设置日志文件，打印信息将打印至stderr
+	LogDebugClose bool   //是否关闭Debug日志级别调试信息 默认false  -- 默认打开debug信息
+}
+
+//注意如果使用UserConf应该调用方法同步至 GlobalConfObject 因为其他参数是调用的此结构体参数
+func UserConfToGlobal(config *Config) {
+
+	//Server配置
+	GlobalObject.Name = config.Name
+	GlobalObject.Host = config.Host
+	GlobalObject.TCPPort = config.TcpPort
+
+	//Zinx配置项设置
+	GlobalObject.Version = config.Version
+	GlobalObject.WorkerPoolSize = config.WorkerPoolSize
+	GlobalObject.MaxConn = config.MaxConn
+	GlobalObject.MaxPacketSize = config.MaxPacketSize
+	GlobalObject.MaxMsgChanLen = config.MaxWorkerTaskLen
+	GlobalObject.MaxMsgChanLen = config.MaxMsgChanLen
+
+	//日志配置项目
+	//默认就是False config没有初始化即使用默认配置
+	GlobalObject.LogDebugClose = config.LogDebugClose
+	//不同于上方必填项 日志目前如果没配置应该使用默认配置
+	if config.LogDir != "" {
+		GlobalObject.LogDir = config.LogDir
+	}
+	if config.LogFile != "" {
+		GlobalObject.LogFile = config.LogFile
+	}
+
+}

--- a/ziface/irequest.go
+++ b/ziface/irequest.go
@@ -21,4 +21,8 @@ type IRequest interface {
 	GetConnection() IConnection //获取请求连接信息
 	GetData() []byte            //获取请求消息的数据
 	GetMsgID() uint32           //获取请求的消息ID
+
+	BindRouter(router IRouter) //绑定这次请求由哪个路由处理
+	Next()                     //转进到下一个处理器开始执行 但是调用此方法的函数会根据先后顺序逆序执行
+	Abort()                    //终止处理函数的运行 但调用此方法的函数会执行完毕
 }

--- a/znet/connection.go
+++ b/znet/connection.go
@@ -122,8 +122,9 @@ func (c *Connection) StartReader() {
 
 			//得到当前客户端请求的Request数据
 			req := Request{
-				conn: c,
-				msg:  msg,
+				conn:  c,
+				msg:   msg,
+				index: 0,
 			}
 
 			if utils.GlobalObject.WorkerPoolSize > 0 {

--- a/znet/msghandler.go
+++ b/znet/msghandler.go
@@ -44,11 +44,15 @@ func (mh *MsgHandle) DoMsgHandler(request ziface.IRequest) {
 		fmt.Println("api msgID = ", request.GetMsgID(), " is not FOUND!")
 		return
 	}
+	//绑定路由
+	request.BindRouter(handler)
+	//request中未赋值的index默认值是0
+	request.Next()
 
 	//执行对应处理方法
-	handler.PreHandle(request)
-	handler.Handle(request)
-	handler.PostHandle(request)
+	//handler.PreHandle(request)
+	//handler.Handle(request)
+	//handler.PostHandle(request)
 }
 
 //AddRouter 为消息添加具体的处理逻辑

--- a/znet/request.go
+++ b/znet/request.go
@@ -4,8 +4,10 @@ import "github.com/aceld/zinx/ziface"
 
 //Request 请求
 type Request struct {
-	conn ziface.IConnection //已经和客户端建立好的 链接
-	msg  ziface.IMessage    //客户端请求的数据
+	conn   ziface.IConnection //已经和客户端建立好的 链接
+	msg    ziface.IMessage    //客户端请求的数据
+	router ziface.IRouter     //请求处理的函数
+	index  int8               //用来控制路由函数执行
 }
 
 //GetConnection 获取请求连接信息
@@ -21,4 +23,27 @@ func (r *Request) GetData() []byte {
 //GetMsgID 获取请求的消息的ID
 func (r *Request) GetMsgID() uint32 {
 	return r.msg.GetMsgID()
+}
+
+func (r *Request) BindRouter(router ziface.IRouter) {
+	r.router = router
+}
+
+func (r *Request) Next() {
+	r.index++
+	for r.index < 4 {
+		switch r.index {
+		case 1:
+			r.router.PreHandle(r)
+		case 2:
+			r.router.Handle(r)
+		case 3:
+			r.router.PostHandle(r)
+		}
+		r.index++
+	}
+}
+
+func (r *Request) Abort() {
+	r.index = 4
 }

--- a/znet/server.go
+++ b/znet/server.go
@@ -69,6 +69,31 @@ func NewServer(opts ...Option) ziface.IServer {
 	return s
 }
 
+//NewServer 创建一个服务器句柄
+func NewUserConfServer(config *utils.Config, opts ...Option) ziface.IServer {
+	//打印logo
+	printLogo()
+
+	s := &Server{
+		Name:       config.Name,
+		IPVersion:  config.TcpVersion,
+		IP:         config.Host,
+		Port:       config.TcpPort,
+		msgHandler: NewMsgHandle(),
+		ConnMgr:    NewConnManager(),
+		exitChan:   nil,
+		packet:     zpack.Factory().NewPack(ziface.ZinxDataPack),
+	}
+	//更替打包方式
+	for _, opt := range opts {
+		opt(s)
+	}
+	//刷新用户配置到全局配置变量
+	utils.UserConfToGlobal(config)
+
+	return s
+}
+
 //============== 实现 ziface.IServer 里的全部接口方法 ========
 
 //Start 开启网络服务


### PR DESCRIPTION
新增一个用户配置类和用户配置构造Server的方法，用户可以通过注入配置的方式通过配置类来实现自定义配置
之前包涵在新路由的PR中，被恢复了

优化原本的路由函数 通过增加 irequest 中的接口方法和修改MsgHandle中的调用方法 在不影响原本方式情况下 提供 之前 PR #162      的Next和Abort 方法


