### PR TITLE
调整 msgBuffChan的初始化 和StartWrite方法启动时机 添加Notify层和i连接映射

### DIFF
--- a/Znotify/ConnAndId.go
+++ b/Znotify/ConnAndId.go
@@ -1,0 +1,11 @@
+package Notify
+
+import (
+	"github.com/aceld/zinx/ziface"
+)
+
+//建立一个用户自定义ID和连接映射的结构
+//map会存在 并发问题，大量数据循环读取问题
+//暂时先用map结构存储，但是应该不是最好的选择，抛砖引玉
+
+type ConnIDMap map[uint64]ziface.IConnection

--- a/Znotify/Notify.go
+++ b/Znotify/Notify.go
@@ -12,10 +12,14 @@ type notify struct {
 	sync.RWMutex
 }
 
-func NewNotify() *notify {
+func NewNotify() ziface.Inotify {
 	return &notify{
 		cimap: make(map[uint64]ziface.IConnection, 5000),
 	}
+}
+
+func (n *notify) ConnNums() int {
+	return len(n.cimap)
 }
 
 func (n *notify) HasIdConn(Id uint64) bool {

--- a/Znotify/Notify.go
+++ b/Znotify/Notify.go
@@ -1,0 +1,128 @@
+package Notify
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aceld/zinx/ziface"
+	"sync"
+)
+
+type notify struct {
+	cimap ConnIDMap
+	sync.RWMutex
+}
+
+func NewNotify() *notify {
+	return &notify{
+		cimap: make(map[uint64]ziface.IConnection, 5000),
+	}
+}
+
+func (n *notify) HasIdConn(Id uint64) bool {
+	n.RLock()
+	defer n.RUnlock()
+	_, ok := n.cimap[Id]
+	return ok
+}
+
+func (n *notify) SetNotifyID(Id uint64, conn ziface.IConnection) {
+	n.Lock()
+	defer n.Unlock()
+	n.cimap[Id] = conn
+}
+
+func (n *notify) GetNotifyByID(Id uint64) (ziface.IConnection, error) {
+	n.RLock()
+	defer n.RUnlock()
+	Conn, ok := n.cimap[Id]
+	if !ok {
+		return nil, errors.New(" Not Find UserId")
+	}
+	return Conn, nil
+}
+
+func (n *notify) DelNotifyByID(Id uint64) {
+	n.RLock()
+	defer n.RUnlock()
+	delete(n.cimap, Id)
+}
+
+func (n *notify) NotifyToConnByID(Id uint64, MsgId uint32, data []byte) error {
+	Conn, err := n.GetNotifyByID(Id)
+	if err != nil {
+		return err
+	}
+	err = Conn.SendMsg(MsgId, data)
+	if err != nil {
+		fmt.Printf("Notify to %d err:%s \n", Id, err)
+		return err
+	}
+	return nil
+}
+
+func (n *notify) NotifyAll(MsgId uint32, data []byte) error {
+	n.RLock()
+	defer n.RUnlock()
+	for Id, v := range n.cimap {
+		err := v.SendMsg(MsgId, data)
+		if err != nil {
+			fmt.Printf("Notify to %d err:%s \n", Id, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (n *notify) notifyAll(MsgId uint32, data []byte) error {
+	n.RLock()
+	defer n.RUnlock()
+	for Id, v := range n.cimap {
+		err := v.SendMsg(MsgId, data)
+		if err != nil {
+			fmt.Printf("Notify to %d err:%s \n", Id, err)
+			return err
+		}
+	}
+	return nil
+}
+
+//极端情况 同时加入和发送的人很多需要尽快释放map的情况， 目前问题很多不采用
+func (n *notify) notifyAll2(MsgId uint32, data []byte) error {
+	conns := make([]ziface.IConnection, 0, len(n.cimap))
+	n.RLock()
+	for _, v := range n.cimap {
+		conns = append(conns, v)
+	}
+	n.RUnlock()
+
+	for i := 0; i < len(conns); i++ {
+		conns[i].SendMsg(MsgId, data)
+	}
+	return nil
+}
+
+func (n *notify) NotifyBuffToConnByID(Id uint64, MsgId uint32, data []byte) error {
+	Conn, err := n.GetNotifyByID(Id)
+	if err != nil {
+		return err
+	}
+	err = Conn.SendBuffMsg(MsgId, data)
+	if err != nil {
+		fmt.Printf("Notify to %d err:%s \n", Id, err)
+		return err
+	}
+	return nil
+}
+
+func (n *notify) NotifyBuffAll(MsgId uint32, data []byte) error {
+	n.RLock()
+	defer n.RUnlock()
+	for Id, v := range n.cimap {
+		err := v.SendBuffMsg(MsgId, data)
+		if err != nil {
+			fmt.Printf("Notify to %d err:%s \n", Id, err)
+			return err
+		}
+	}
+	return nil
+}

--- a/Znotify/Notify_test.go
+++ b/Znotify/Notify_test.go
@@ -110,9 +110,9 @@ func ClinetJoin() {
 
 func TestAA(t *testing.T) {
 	time.AfterFunc(5*time.Second, func() {
-		fmt.Println(len(nt.cimap))
 	})
 	time.Sleep(6 * time.Second)
+	nt.ConnNums()
 }
 
 func BenchmarkNotify(b *testing.B) {
@@ -121,5 +121,5 @@ func BenchmarkNotify(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		nt.NotifyAll(1, []byte("雪下的是盐"))
 	}
-	fmt.Println(len(nt.cimap))
+	nt.ConnNums()
 }

--- a/Znotify/Notify_test.go
+++ b/Znotify/Notify_test.go
@@ -1,0 +1,127 @@
+package Notify
+
+import (
+	"fmt"
+	"github.com/aceld/zinx/utils"
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/znet"
+	"github.com/aceld/zinx/zpack"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+var nt = NewNotify()
+
+type router struct {
+	znet.BaseRouter
+}
+
+func (r *router) Handle(req ziface.IRequest) {
+	id, _ := strconv.Atoi(string(req.GetData()))
+	nt.SetNotifyID(uint64(id), req.GetConnection())
+}
+
+func Server() {
+	s := znet.NewUserConfServer(&utils.Config{
+		Host:             "127.0.0.1",
+		TcpPort:          9991,
+		Name:             "NtTest",
+		TcpVersion:       "tcp",
+		Version:          "1",
+		MaxConn:          10000,
+		MaxPacketSize:    4096,
+		WorkerPoolSize:   10,
+		MaxWorkerTaskLen: 10,
+		MaxMsgChanLen:    10,
+	})
+
+	s.AddRouter(1, &router{})
+	s.Serve()
+}
+
+func Clinet() {
+	//conf.ConfigInit()
+	//1创建直接链接
+	for i := 0; i < 9000; i++ {
+		go func(i int) {
+			conn, err := net.Dial("tcp", "127.0.0.1:9991")
+			if err != nil {
+				fmt.Println("net dial err:", err)
+				return
+			}
+			defer conn.Close()
+			//链接调用write方法写入数据
+			id := strconv.Itoa(i)
+			dp := zpack.NewDataPack()
+			msg, err := dp.Pack(zpack.NewMsgPackage(1, []byte(id)))
+			if err != nil {
+				return
+			}
+			_, err = conn.Write(msg)
+
+			if err != nil {
+				return
+			}
+			select {}
+			//fmt.Println("==> Recv Msg: ID=", NewMsg.GetMsgId(), ", len=", NewMsg.GetDataLen(), ", data=", string(NewMsg.GetData()))
+		}(i)
+	}
+}
+
+func init() {
+	go Server()
+	go Clinet()
+	go ClinetJoin()
+}
+
+func ClinetJoin() {
+	t := time.NewTicker(50 * time.Millisecond)
+	i := 10000
+	for {
+		select {
+		case <-t.C:
+			go func(i int) {
+				conn, err := net.Dial("tcp", "127.0.0.1:9991")
+				if err != nil {
+					fmt.Println("net dial err:", err)
+					return
+				}
+				defer conn.Close()
+				//链接调用write方法写入数据
+				id := strconv.Itoa(i)
+				dp := zpack.NewDataPack()
+				msg, err := dp.Pack(zpack.NewMsgPackage(1, []byte(id)))
+				if err != nil {
+					return
+				}
+				_, err = conn.Write(msg)
+
+				if err != nil {
+					return
+				}
+				select {}
+				//fmt.Println("==> Recv Msg: ID=", NewMsg.GetMsgId(), ", len=", NewMsg.GetDataLen(), ", data=", string(NewMsg.GetData()))
+			}(i)
+			i++
+		}
+	}
+
+}
+
+func TestAA(t *testing.T) {
+	time.AfterFunc(5*time.Second, func() {
+		fmt.Println(len(nt.cimap))
+	})
+	time.Sleep(6 * time.Second)
+}
+
+func BenchmarkNotify(b *testing.B) {
+	time.Sleep(5 * time.Second)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nt.NotifyAll(1, []byte("雪下的是盐"))
+	}
+	fmt.Println(len(nt.cimap))
+}

--- a/Znotify/Notify_test.go
+++ b/Znotify/Notify_test.go
@@ -65,7 +65,6 @@ func Clinet() {
 				return
 			}
 			select {}
-			//fmt.Println("==> Recv Msg: ID=", NewMsg.GetMsgId(), ", len=", NewMsg.GetDataLen(), ", data=", string(NewMsg.GetData()))
 		}(i)
 	}
 }
@@ -102,7 +101,6 @@ func ClinetJoin() {
 					return
 				}
 				select {}
-				//fmt.Println("==> Recv Msg: ID=", NewMsg.GetMsgId(), ", len=", NewMsg.GetDataLen(), ", data=", string(NewMsg.GetData()))
 			}(i)
 			i++
 		}

--- a/Znotify/conf/zinx.json
+++ b/Znotify/conf/zinx.json
@@ -1,0 +1,7 @@
+{
+  "Name":"zinx server Demo",
+  "Host":"127.0.0.1",
+  "TcpPort":8999,
+  "MaxConn":3,
+  "WorkerPoolSize":10
+}

--- a/ziface/Inotify.go
+++ b/ziface/Inotify.go
@@ -1,12 +1,20 @@
 package ziface
 
 type Inotify interface {
+	//是否有这个id
 	HasIdConn(id uint64) bool
+	//存储的map长度
+	ConnNums() int
+	//添加链接
+	SetNotifyID(Id uint64, conn IConnection)
+	//得到某个链接
+	GetNotifyByID(Id uint64) (IConnection, error)
+	//删除某个链接
+	DelNotifyByID(Id uint64)
 	//通知某个id的方法
 	NotifyToConnByID(Id uint64, MsgId uint32, data []byte) error
 	//通知所有人
 	NotifyAll(MsgId uint32, data []byte) error
-
 	//通过缓冲队列通知某个id的方法
 	NotifyBuffToConnByID(Id uint64, MsgId uint32, data []byte) error
 	//缓冲队列通知所有人

--- a/ziface/Inotify.go
+++ b/ziface/Inotify.go
@@ -1,0 +1,14 @@
+package ziface
+
+type Inotify interface {
+	HasIdConn(id uint64) bool
+	//通知某个id的方法
+	NotifyToConnByID(Id uint64, MsgId uint32, data []byte) error
+	//通知所有人
+	NotifyAll(MsgId uint32, data []byte) error
+
+	//通过缓冲队列通知某个id的方法
+	NotifyBuffToConnByID(Id uint64, MsgId uint32, data []byte) error
+	//缓冲队列通知所有人
+	NotifyBuffAll(MsgId uint32, data []byte) error
+}

--- a/znet/connection.go
+++ b/znet/connection.go
@@ -289,7 +289,9 @@ func (c *Connection) finalizer() {
 	c.TCPServer.GetConnMgr().Remove(c)
 
 	//关闭该链接全部管道
-	close(c.msgBuffChan)
+	if c.msgBuffChan != nil {
+		close(c.msgBuffChan)
+	}
 	//设置标志位
 	c.isClosed = true
 }

--- a/znet/connection.go
+++ b/znet/connection.go
@@ -48,7 +48,7 @@ func NewConnection(server ziface.IServer, conn *net.TCPConn, connID uint32, msgH
 		ConnID:      connID,
 		isClosed:    false,
 		MsgHandler:  msgHandler,
-		msgBuffChan: make(chan []byte, utils.GlobalObject.MaxMsgChanLen),
+		msgBuffChan: nil,
 		property:    nil,
 	}
 
@@ -145,8 +145,6 @@ func (c *Connection) Start() {
 	c.TCPServer.CallOnConnStart(c)
 	//1 开启用户从客户端读取数据流程的Goroutine
 	go c.StartReader()
-	//2 开启用于写回客户端数据流程的Goroutine
-	go c.StartWriter()
 
 	select {
 	case <-c.ctx.Done():
@@ -200,6 +198,12 @@ func (c *Connection) SendMsg(msgID uint32, data []byte) error {
 func (c *Connection) SendBuffMsg(msgID uint32, data []byte) error {
 	c.RLock()
 	defer c.RUnlock()
+	if c.msgBuffChan == nil {
+		c.msgBuffChan = make(chan []byte, utils.GlobalObject.MaxMsgChanLen)
+		//开启用于写回客户端数据流程的Goroutine
+		//此方法只读取MsgBuffChan中的数据没调用SendBuffMsg可以分配内存和启用协程
+		go c.StartWriter()
+	}
 	idleTimeout := time.NewTimer(5 * time.Millisecond)
 	defer idleTimeout.Stop()
 


### PR DESCRIPTION
1.调整 msgBuffChan的初始化，如果没有调用过SendBuffMsg则不初始化，且也不启动StartWrite方法，因为此方法目前只会读取msgBuffChan中的值 。并且 在finalizer()方法执行中再判断一下 msgBuffChan是否开启，开启才关闭这个管道否则会panic
2. 添加了一个id和Conn的映射和Notify接口和操作，用以提供 #169  Issues的提案的实现，通过id映射由框架来发送通知 来实现如 ：玩家对玩家的聊天，单独对某个玩家的通知或者是全体通知类的操作