### PR TITLE
fix(typos): 修复一些文本错误

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -259,7 +259,7 @@ recv from client : msgId= 1 , data= Ping...Ping...Ping...[FromClient]
 {
   "Name":"zinx v-0.10 demoApp",
   "Host":"127.0.0.1",
-  "TcpPort":7777,
+  "TCPPort":7777,
   "MaxConn":3,
   "WorkerPoolSize":10,
   "LogDir": "./mylog",

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ recv from client : msgId= 1 , data= Ping...Ping...Ping...[FromClient]
 {
   "Name":"zinx v-0.10 demoApp",
   "Host":"127.0.0.1",
-  "TcpPort":7777,
+  "TCPPort":7777,
   "MaxConn":3,
   "WorkerPoolSize":10,
   "LogDir": "./mylog",

--- a/examples/zinx_interceptor/interceptors/interceptor_1.go
+++ b/examples/zinx_interceptor/interceptors/interceptor_1.go
@@ -9,7 +9,7 @@ import (
 
 type MyInterceptor struct{}
 
-func (m *MyInterceptor) Intercept(chain ziface.Chain) ziface.IterResp {
+func (m *MyInterceptor) Intercept(chain ziface.IChain) ziface.IcResp {
 	request := chain.Request()
 	// 这一层是自定义拦截器处理逻辑，这里只是简单打印输入
 	iRequest := request.(ziface.IRequest)

--- a/znet/heartbeat.go
+++ b/znet/heartbeat.go
@@ -143,7 +143,7 @@ func (h *HeartbeatChecker) BindConn(conn ziface.IConnection) {
 // CloneTo 克隆到一个指定的链接上
 func (h *HeartbeatChecker) Clone() ziface.IHeartbeatChecker {
 
-	heatbeat := &HeartbeatChecker{
+	heartbeat := &HeartbeatChecker{
 		interval:         h.interval,
 		quitChan:         make(chan bool),
 		makeMsg:          h.makeMsg,
@@ -153,7 +153,7 @@ func (h *HeartbeatChecker) Clone() ziface.IHeartbeatChecker {
 		conn:             nil, //绑定的链接需要重新赋值
 	}
 
-	return heatbeat
+	return heartbeat
 }
 
 func (h *HeartbeatChecker) MsgID() uint32 {

--- a/znotify/notify.go
+++ b/znotify/notify.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 )
 
-//建立一个用户自定义ID和连接映射的结构
-//map会存在 并发问题，大量数据循环读取问题
-//暂时先用map结构存储，但是应该不是最好的选择，抛砖引玉
+// 建立一个用户自定义ID和连接映射的结构
+// map会存在 并发问题，大量数据循环读取问题
+// 暂时先用map结构存储，但是应该不是最好的选择，抛砖引玉
 type ConnIDMap map[uint64]ziface.IConnection
 
 type notify struct {
@@ -77,7 +77,6 @@ func (n *notify) NotifyAll(MsgId uint32, data []byte) error {
 		err := v.SendMsg(MsgId, data)
 		if err != nil {
 			zlog.Ins().ErrorF("Notify to %d err:%s \n", Id, err)
-			return err
 		}
 	}
 	return nil
@@ -90,13 +89,12 @@ func (n *notify) notifyAll(MsgId uint32, data []byte) error {
 		err := v.SendMsg(MsgId, data)
 		if err != nil {
 			zlog.Ins().ErrorF("Notify to %d err:%s \n", Id, err)
-			return err
 		}
 	}
 	return nil
 }
 
-//极端情况 同时加入和发送的人很多需要尽快释放map的情况， 目前问题很多不采用
+// 极端情况 同时加入和发送的人很多需要尽快释放map的情况， 目前问题很多不采用
 func (n *notify) notifyAll2(MsgId uint32, data []byte) error {
 	conns := make([]ziface.IConnection, 0, len(n.cimap))
 	n.RLock()
@@ -131,7 +129,6 @@ func (n *notify) NotifyBuffAll(MsgId uint32, data []byte) error {
 		err := v.SendBuffMsg(MsgId, data)
 		if err != nil {
 			zlog.Ins().ErrorF("Notify to %d err:%s \n", Id, err)
-			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
1. 修复一些文本和引用错误
2. notify 全量推送时，单个链接错误不应该直接return,应该继续执行其他的conn