### PR TITLE
修正了一些网络连接相关的问题

### DIFF
--- a/zinterceptor/builder.go
+++ b/zinterceptor/builder.go
@@ -12,7 +12,6 @@ import "github.com/aceld/zinx/ziface"
 type Builder struct {
 	body       []ziface.IInterceptor
 	head, tail ziface.IInterceptor
-	req        ziface.IcReq
 }
 
 func NewBuilder() ziface.IBuilder {
@@ -34,7 +33,6 @@ func (ic *Builder) AddInterceptor(interceptor ziface.IInterceptor) {
 }
 
 func (ic *Builder) Execute(req ziface.IcReq) ziface.IcResp {
-	ic.req = req
 
 	//将全部拦截器放入Builder中
 	var interceptors []ziface.IInterceptor
@@ -52,5 +50,5 @@ func (ic *Builder) Execute(req ziface.IcReq) ziface.IcResp {
 	chain := NewChain(interceptors, 0, req)
 
 	//进入责任链执行
-	return chain.Proceed(ic.req)
+	return chain.Proceed(req)
 }

--- a/zinterceptor/framedocder.go
+++ b/zinterceptor/framedocder.go
@@ -406,7 +406,7 @@ func (d *FrameDecoder) getUnadjustedFrameLength(buf *bytes.Buffer, offset int, l
 		}
 	case 4:
 		//int
-		var value int32
+		var value uint32
 		binary.Read(buffer, order, &value)
 		frameLength = int64(value)
 	case 8:

--- a/znet/heartbeat.go
+++ b/znet/heartbeat.go
@@ -159,6 +159,7 @@ func (h *HeartbeatChecker) Clone() ziface.IHeartbeatChecker {
 	heartbeat := &HeartbeatChecker{
 		interval:         h.interval,
 		quitChan:         make(chan bool),
+		beatFunc:         h.beatFunc,
 		makeMsg:          h.makeMsg,
 		onRemoteNotAlive: h.onRemoteNotAlive,
 		msgID:            h.msgID,

--- a/znet/server.go
+++ b/znet/server.go
@@ -249,7 +249,7 @@ func (s *Server) Start() {
 
 				} else {
 					//3.4 处理该新连接请求的 业务 方法， 此时应该有 handler 和 conn是绑定的
-					dealConn = newServerConn(s, conn, cID)
+					dealConn = newServerConn(s, conn, cID, reader)
 
 					// TCP HeartBeat 心跳检测
 					if s.hc != nil {


### PR DESCRIPTION
1，修正大量玩家（比如100名）同时发起请求时的数据竞争问题。
    原因：所有消息处理中使用的Builder都是同一对象，而ic.req在责任链调用req.SetData时会发生错乱
2，修正getUnadjustedFrameLength中客户端发送恶意数据时，返回负数并引发panic的问题。
    原因：4字节的最大值是MaxUint32而非MaxInt32
3，修正reader.Peek造成第一条消息丢失的问题。
    原因：执行reader.Peek后，conn的数据已经被扇出，后续应该使用reader而非conn。
4，修正用户自定义beatfunc无效的问题
    原因： (h *HeartbeatChecker) Clone()中，beatfunc未被克隆