### PR TITLE
Fixed issues that would cause the server to stop

### DIFF
--- a/znet/connection.go
+++ b/znet/connection.go
@@ -4,6 +4,7 @@
 package znet
 
 import (
+	"bufio"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -103,6 +104,7 @@ func newClientConn(client ziface.IClient, conn net.Conn) ziface.IConnection {
 		isClosed:    false,
 		msgBuffChan: nil,
 		property:    nil,
+		reader:      bufio.NewReader(conn),
 	}
 
 	lengthField := client.GetLengthField()

--- a/znet/responsewriter.go
+++ b/znet/responsewriter.go
@@ -20,7 +20,8 @@ func newResponseWriter(conn *net.TCPConn, reader *bufio.Reader) *customWriterRec
 }
 
 func (w *customWriterRecorder) Header() http.Header {
-	return nil
+	zlog.Ins().ErrorF("Header has not been implemented")
+	return http.Header{}
 }
 
 func (w *customWriterRecorder) Write(bytes []byte) (int, error) {
@@ -29,7 +30,7 @@ func (w *customWriterRecorder) Write(bytes []byte) (int, error) {
 
 func (w *customWriterRecorder) WriteHeader(statusCode int) {
 	//TODO implement me
-	panic("implement me")
+	zlog.Ins().ErrorF("WriteHeader has not been implemented")
 }
 func (w *customWriterRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return w.conn, w.rw, nil

--- a/znet/responsewriter.go
+++ b/znet/responsewriter.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"net"
 	"net/http"
+	"github.com/aceld/zinx/zlog"
 )
 
 type customWriterRecorder struct {
@@ -32,6 +33,7 @@ func (w *customWriterRecorder) WriteHeader(statusCode int) {
 	//TODO implement me
 	zlog.Ins().ErrorF("WriteHeader has not been implemented")
 }
+
 func (w *customWriterRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return w.conn, w.rw, nil
 }

--- a/znet/server.go
+++ b/znet/server.go
@@ -132,7 +132,52 @@ func NewUserConfServer(config *zconf.Config, opts ...Option) ziface.IServer {
 	return s
 }
 
-//============== 实现 ziface.IServer 里的全部接口方法 ========
+// ============== 实现 ziface.IServer 里的全部接口方法 ========
+func (s *Server) StartConn(conn net.Conn, cID uint64) {
+	var dealConn ziface.IConnection
+	reader := bufio.NewReader(conn)
+	peek, err := reader.Peek(1)
+	if err != nil {
+		zlog.Ins().ErrorF("Error peeking request err:%v", err)
+		return
+	}
+	// 3.3 判断连接是否是 HTTP 请求
+	if peek[0] == 'G' || peek[0] == 'P' || peek[0] == 'H' {
+		// 处理 HTTP 请求
+		// 创建 http ResponseWriter
+		w := newResponseWriter(conn.(*net.TCPConn), reader)
+		// 把http连接解析成request
+		request, err := http.ReadRequest(reader)
+		if err != nil {
+			zlog.Ins().ErrorF("Error reading HTTP request err:%v", err)
+			return
+		}
+		// 3.4 把 net.conn 转成 websocket.conn 模式
+		wsConn, err := s.upgrader.Upgrade(w, request, nil)
+		if err != nil {
+			zlog.Ins().ErrorF("http convert websocket error:%v", err)
+			return
+		}
+		// 3.5 处理该新连接请求的 业务 方法， 此时应该有 handler 和 conn是绑定的
+		dealConn = newWebsocketConn(s, wsConn, cID)
+
+	} else {
+		//3.4 处理该新连接请求的 业务 方法， 此时应该有 handler 和 conn是绑定的
+		dealConn = newServerConn(s, conn, cID, reader)
+	}
+
+	// HeartBeat 心跳检测
+	if s.hc != nil {
+		//从Server端克隆一个心跳检测器
+		heartBeatChecker := s.hc.Clone()
+
+		//绑定当前链接
+		heartBeatChecker.BindConn(dealConn)
+	}
+
+	//3.4 启动当前链接的处理业务
+	dealConn.Start()
+}
 
 // Start 开启网络服务
 func (s *Server) Start() {
@@ -210,50 +255,9 @@ func (s *Server) Start() {
 
 				AcceptDelay.Reset()
 
-				var dealConn ziface.IConnection
-				reader := bufio.NewReader(conn)
-				peek, err := reader.Peek(1)
-				if err != nil {
-					zlog.Ins().ErrorF("Error peeking request err:%v", err)
-					return
-				}
-				// 3.3 判断连接是否是 HTTP 请求
-				if peek[0] == 'G' || peek[0] == 'P' || peek[0] == 'H' {
-					// 处理 HTTP 请求
-					// 创建 http ResponseWriter
-					w := newResponseWriter(conn.(*net.TCPConn), reader)
-					// 把http连接解析成request
-					request, err := http.ReadRequest(reader)
-					if err != nil {
-						zlog.Ins().ErrorF("Error reading HTTP request err:%v", err)
-						return
-					}
-					// 3.4 把 net.conn 转成 websocket.conn 模式
-					wsConn, err := s.upgrader.Upgrade(w, request, nil)
-					if err != nil {
-						zlog.Ins().ErrorF("http convert websocket error:%v", err)
-						return
-					}
-					// 3.5 处理该新连接请求的 业务 方法， 此时应该有 handler 和 conn是绑定的
-					dealConn = newWebsocketConn(s, wsConn, cID)
-
-				} else {
-					//3.4 处理该新连接请求的 业务 方法， 此时应该有 handler 和 conn是绑定的
-					dealConn = newServerConn(s, conn, cID, reader)
-				}
-
-				// HeartBeat 心跳检测
-				if s.hc != nil {
-					//从Server端克隆一个心跳检测器
-					heartBeatChecker := s.hc.Clone()
-
-					//绑定当前链接
-					heartBeatChecker.BindConn(dealConn)
-				}
+				go s.StartConn(conn, cID)
 
 				cID++
-				//3.4 启动当前链接的处理业务
-				go dealConn.Start()
 			}
 		}()
 


### PR DESCRIPTION
1，修正example/client由于没有reader无法正常运行的问题；
2，修正wsConn中用户自定义beatfunc无效的问题；
3，修正用户非法访问（比如在浏览器地址栏直接输入服务器host）时，引发panic的问题；
4，修正reader.Peek在用户非法访问（比如建立tcp连接后不发送任何消息）时，会导致新client无法被Accept的问题。