### PR TITLE
配置化并发读取消息池数量

### DIFF
--- a/examples/zinx_routerSlices/Clinet.go
+++ b/examples/zinx_routerSlices/Clinet.go
@@ -14,11 +14,14 @@ func main() {
 	}
 
 	dp := zpack.NewDataPack()
-	msg, _ := dp.Pack(zpack.NewMsgPackage(1, []byte("ZinxPing")))
-	_, err = conn.Write(msg)
-	if err != nil {
-		fmt.Println("write error err ", err)
-		return
+	for i := 1; i < 4; i++ {
+		msg, _ := dp.Pack(zpack.NewMsgPackage(uint32(i), []byte("ZinxPing")))
+		fmt.Println(i)
+		_, err = conn.Write(msg)
+		if err != nil {
+			fmt.Println("write error err ", err)
+			return
+		}
 	}
 
 }

--- a/examples/zinx_routerSlices/RouterFuncApi.go
+++ b/examples/zinx_routerSlices/RouterFuncApi.go
@@ -39,7 +39,7 @@ func TestFunc(request ziface.IRequest) {
 func main() {
 
 	// New version usage and explanation.(新版本使用方法以及说明)
-	server := znet.NewUserConfServer(&zconf.Config{RouterSlicesMode: true, TCPPort: 8999, Host: "127.0.0.1"})
+	server := znet.NewUserConfServer(&zconf.Config{RouterSlicesMode: true, TCPPort: 8999, Host: "127.0.0.1", WorkerPoolGoroutineNums: 3})
 
 	// Simulation scenario 1: A normal business that only executes a single operation function separately.
 	// 模拟场景 1，普通业务单独只执行一个操作函数

--- a/examples/zinx_routerSlices/server2.go
+++ b/examples/zinx_routerSlices/server2.go
@@ -27,6 +27,8 @@ func f3(request ziface.IRequest) {
 func main() {
 
 	server := znet.NewUserConfServer(&zconf.Config{RouterSlicesMode: true, TCPPort: 8999, Host: "127.0.0.1", WorkerPoolGoroutineNums: 1})
+	//配置大于1
+	//server := znet.NewUserConfServer(&zconf.Config{RouterSlicesMode: true, TCPPort: 8999, Host: "127.0.0.1", WorkerPoolGoroutineNums: 2})
 	server.Use(znet.RouterTime)
 	server.AddRouterSlices(1, f1)
 	server.AddRouterSlices(2, f2)

--- a/examples/zinx_routerSlices/server2.go
+++ b/examples/zinx_routerSlices/server2.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"github.com/aceld/zinx/zconf"
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/znet"
+	"time"
+)
+
+// WorkerPoolGoroutineNums 实例
+// 模拟阻塞场景，f1函数会阻塞500ms 如果设置WorkerPoolGoroutineNums数量大于1就可以让同一个消息队列中的chan能够执行而非阻塞
+// 如果默认场景则一定会等f1阻塞执行完成 整个chan才会接着读取执行任务
+// 警告！WorkerPoolGoroutineNums>1会导致同一chan中的消息执行顺序不可控！注意应该使用在不需要注意消息处理顺序的场景
+func f1(request ziface.IRequest) {
+	time.Sleep(500 * time.Millisecond)
+	fmt.Println("我是阻塞函数")
+
+}
+func f2(request ziface.IRequest) {
+	fmt.Println("Test2")
+}
+func f3(request ziface.IRequest) {
+	fmt.Println("Test3")
+}
+
+func main() {
+
+	server := znet.NewUserConfServer(&zconf.Config{RouterSlicesMode: true, TCPPort: 8999, Host: "127.0.0.1", WorkerPoolGoroutineNums: 1})
+	server.Use(znet.RouterTime)
+	server.AddRouterSlices(1, f1)
+	server.AddRouterSlices(2, f2)
+	server.AddRouterSlices(3, f3)
+	server.Serve()
+}

--- a/zconf/globalobj.go
+++ b/zconf/globalobj.go
@@ -45,7 +45,7 @@ type Config struct {
 	MaxPacketSize           uint32 //The maximum size of the packets that can be sent or received.(读写数据包的最大值)
 	MaxConn                 int    //The maximum number of connections that the server can handle.(当前服务器主机允许的最大链接个数)
 	WorkerPoolSize          uint32 //The number of worker pools in the business logic.(业务工作Worker池的数量)
-	WorkerPoolGoroutineNums uint32 //从业务工作Worker池去读取消息的协程数量
+	WorkerPoolGoroutineNums uint32 //从业务工作Worker池去读取消息的协程数量 警告！WorkerPoolGoroutineNums>1会导致同一chan中的消息执行顺序不可控！
 	MaxWorkerTaskLen        uint32 //The maximum number of tasks that a worker pool can handle.(业务工作Worker对应负责的任务队列最大任务存储数量)
 	MaxMsgChanLen           uint32 //The maximum length of the send buffer message queue.(SendBuffMsg发送消息的缓冲最大长度)
 	IOReadBuffSize          uint32 //The maximum size of the read buffer for each IO operation.(每次IO最大的读取长度)

--- a/zconf/globalobj.go
+++ b/zconf/globalobj.go
@@ -41,14 +41,14 @@ type Config struct {
 	/*
 		Zinx
 	*/
-	Version             string //The version of the Zinx framework.(当前Zinx版本号)
-	MaxPacketSize       uint32 //The maximum size of the packets that can be sent or received.(读写数据包的最大值)
-	MaxConn             int    //The maximum number of connections that the server can handle.(当前服务器主机允许的最大链接个数)
-	WorkerPoolSize      uint32 //The number of worker pools in the business logic.(业务工作Worker池的数量)
-	WorkerGoroutineNums uint32 //从业务工作Worker池去读取消息的协程数量
-	MaxWorkerTaskLen    uint32 //The maximum number of tasks that a worker pool can handle.(业务工作Worker对应负责的任务队列最大任务存储数量)
-	MaxMsgChanLen       uint32 //The maximum length of the send buffer message queue.(SendBuffMsg发送消息的缓冲最大长度)
-	IOReadBuffSize      uint32 //The maximum size of the read buffer for each IO operation.(每次IO最大的读取长度)
+	Version                 string //The version of the Zinx framework.(当前Zinx版本号)
+	MaxPacketSize           uint32 //The maximum size of the packets that can be sent or received.(读写数据包的最大值)
+	MaxConn                 int    //The maximum number of connections that the server can handle.(当前服务器主机允许的最大链接个数)
+	WorkerPoolSize          uint32 //The number of worker pools in the business logic.(业务工作Worker池的数量)
+	WorkerPoolGoroutineNums uint32 //从业务工作Worker池去读取消息的协程数量
+	MaxWorkerTaskLen        uint32 //The maximum number of tasks that a worker pool can handle.(业务工作Worker对应负责的任务队列最大任务存储数量)
+	MaxMsgChanLen           uint32 //The maximum length of the send buffer message queue.(SendBuffMsg发送消息的缓冲最大长度)
+	IOReadBuffSize          uint32 //The maximum size of the read buffer for each IO operation.(每次IO最大的读取长度)
 
 	//The server mode, which can be "tcp" or "websocket". If it is empty, both modes are enabled.
 	//"tcp":tcp监听, "websocket":websocket 监听 为空时同时开启
@@ -183,26 +183,26 @@ func init() {
 	// Initialize the GlobalObject variable and set some default values.
 	// (初始化GlobalObject变量，设置一些默认值)
 	GlobalObject = &Config{
-		Name:                "ZinxServerApp",
-		Version:             "V1.0",
-		TCPPort:             8999,
-		WsPort:              9000,
-		Host:                "0.0.0.0",
-		MaxConn:             12000,
-		MaxPacketSize:       4096,
-		WorkerPoolSize:      10,
-		MaxWorkerTaskLen:    1024,
-		MaxMsgChanLen:       1024,
-		LogDir:              pwd + "/log",
-		LogFile:             "", //if set "", print to Stderr(默认日志文件为空，打印到stderr)
-		LogIsolationLevel:   0,
-		HeartbeatMax:        10, //The default maximum interval for heartbeat detection is 10 seconds. (默认心跳检测最长间隔为10秒)
-		IOReadBuffSize:      1024,
-		CertFile:            "",
-		PrivateKeyFile:      "",
-		Mode:                ServerModeTcp,
-		RouterSlicesMode:    false,
-		WorkerGoroutineNums: 1, //默认为1,与之前保持一致
+		Name:                    "ZinxServerApp",
+		Version:                 "V1.0",
+		TCPPort:                 8999,
+		WsPort:                  9000,
+		Host:                    "0.0.0.0",
+		MaxConn:                 12000,
+		MaxPacketSize:           4096,
+		WorkerPoolSize:          10,
+		MaxWorkerTaskLen:        1024,
+		MaxMsgChanLen:           1024,
+		LogDir:                  pwd + "/log",
+		LogFile:                 "", //if set "", print to Stderr(默认日志文件为空，打印到stderr)
+		LogIsolationLevel:       0,
+		HeartbeatMax:            10, //The default maximum interval for heartbeat detection is 10 seconds. (默认心跳检测最长间隔为10秒)
+		IOReadBuffSize:          1024,
+		CertFile:                "",
+		PrivateKeyFile:          "",
+		Mode:                    ServerModeTcp,
+		RouterSlicesMode:        false,
+		WorkerPoolGoroutineNums: 1, //默认为1,与之前保持一致
 	}
 
 	// Note: Load some user-configured parameters from the configuration file.

--- a/zconf/globalobj.go
+++ b/zconf/globalobj.go
@@ -24,10 +24,10 @@ const (
 )
 
 /*
-   Store all global parameters related to the Zinx framework for use by other modules.
-   Some parameters can also be configured by the user based on the zinx.json file.
-	(存储一切有关Zinx框架的全局参数，供其他模块使用
-	一些参数也可以通过 用户根据 zinx.json来配置)
+	   Store all global parameters related to the Zinx framework for use by other modules.
+	   Some parameters can also be configured by the user based on the zinx.json file.
+		(存储一切有关Zinx框架的全局参数，供其他模块使用
+		一些参数也可以通过 用户根据 zinx.json来配置)
 */
 type Config struct {
 	/*
@@ -41,13 +41,14 @@ type Config struct {
 	/*
 		Zinx
 	*/
-	Version          string //The version of the Zinx framework.(当前Zinx版本号)
-	MaxPacketSize    uint32 //The maximum size of the packets that can be sent or received.(读写数据包的最大值)
-	MaxConn          int    //The maximum number of connections that the server can handle.(当前服务器主机允许的最大链接个数)
-	WorkerPoolSize   uint32 //The number of worker pools in the business logic.(业务工作Worker池的数量)
-	MaxWorkerTaskLen uint32 //The maximum number of tasks that a worker pool can handle.(业务工作Worker对应负责的任务队列最大任务存储数量)
-	MaxMsgChanLen    uint32 //The maximum length of the send buffer message queue.(SendBuffMsg发送消息的缓冲最大长度)
-	IOReadBuffSize   uint32 //The maximum size of the read buffer for each IO operation.(每次IO最大的读取长度)
+	Version             string //The version of the Zinx framework.(当前Zinx版本号)
+	MaxPacketSize       uint32 //The maximum size of the packets that can be sent or received.(读写数据包的最大值)
+	MaxConn             int    //The maximum number of connections that the server can handle.(当前服务器主机允许的最大链接个数)
+	WorkerPoolSize      uint32 //The number of worker pools in the business logic.(业务工作Worker池的数量)
+	WorkerGoroutineNums uint32 //从业务工作Worker池去读取消息的协程数量
+	MaxWorkerTaskLen    uint32 //The maximum number of tasks that a worker pool can handle.(业务工作Worker对应负责的任务队列最大任务存储数量)
+	MaxMsgChanLen       uint32 //The maximum length of the send buffer message queue.(SendBuffMsg发送消息的缓冲最大长度)
+	IOReadBuffSize      uint32 //The maximum size of the read buffer for each IO operation.(每次IO最大的读取长度)
 
 	//The server mode, which can be "tcp" or "websocket". If it is empty, both modes are enabled.
 	//"tcp":tcp监听, "websocket":websocket 监听 为空时同时开启
@@ -85,7 +86,7 @@ type Config struct {
 }
 
 /*
-	Define a global object.(定义一个全局的对象)
+Define a global object.(定义一个全局的对象)
 */
 var GlobalObject *Config
 
@@ -161,7 +162,7 @@ func (g *Config) InitLogConfig() {
 }
 
 /*
-	init, set default value
+init, set default value
 */
 func init() {
 	pwd, err := os.Getwd()
@@ -182,25 +183,26 @@ func init() {
 	// Initialize the GlobalObject variable and set some default values.
 	// (初始化GlobalObject变量，设置一些默认值)
 	GlobalObject = &Config{
-		Name:              "ZinxServerApp",
-		Version:           "V1.0",
-		TCPPort:           8999,
-		WsPort:            9000,
-		Host:              "0.0.0.0",
-		MaxConn:           12000,
-		MaxPacketSize:     4096,
-		WorkerPoolSize:    10,
-		MaxWorkerTaskLen:  1024,
-		MaxMsgChanLen:     1024,
-		LogDir:            pwd + "/log",
-		LogFile:           "", //if set "", print to Stderr(默认日志文件为空，打印到stderr)
-		LogIsolationLevel: 0,
-		HeartbeatMax:      10, //The default maximum interval for heartbeat detection is 10 seconds. (默认心跳检测最长间隔为10秒)
-		IOReadBuffSize:    1024,
-		CertFile:          "",
-		PrivateKeyFile:    "",
-		Mode:              ServerModeTcp,
-		RouterSlicesMode:  false,
+		Name:                "ZinxServerApp",
+		Version:             "V1.0",
+		TCPPort:             8999,
+		WsPort:              9000,
+		Host:                "0.0.0.0",
+		MaxConn:             12000,
+		MaxPacketSize:       4096,
+		WorkerPoolSize:      10,
+		MaxWorkerTaskLen:    1024,
+		MaxMsgChanLen:       1024,
+		LogDir:              pwd + "/log",
+		LogFile:             "", //if set "", print to Stderr(默认日志文件为空，打印到stderr)
+		LogIsolationLevel:   0,
+		HeartbeatMax:        10, //The default maximum interval for heartbeat detection is 10 seconds. (默认心跳检测最长间隔为10秒)
+		IOReadBuffSize:      1024,
+		CertFile:            "",
+		PrivateKeyFile:      "",
+		Mode:                ServerModeTcp,
+		RouterSlicesMode:    false,
+		WorkerGoroutineNums: 1, //默认为1,与之前保持一致
 	}
 
 	// Note: Load some user-configured parameters from the configuration file.

--- a/zconf/userconf.go
+++ b/zconf/userconf.go
@@ -35,11 +35,17 @@ func UserConfToGlobal(config *Config) {
 	if config.MaxWorkerTaskLen != 0 {
 		GlobalObject.MaxWorkerTaskLen = config.MaxWorkerTaskLen
 	}
+	if config.WorkerGoroutineNums > 0 {
+		GlobalObject.WorkerGoroutineNums = config.WorkerGoroutineNums
+	}
 	if config.MaxMsgChanLen != 0 {
 		GlobalObject.MaxMsgChanLen = config.MaxMsgChanLen
 	}
 	if config.IOReadBuffSize != 0 {
 		GlobalObject.IOReadBuffSize = config.IOReadBuffSize
+	}
+	if config.RouterSlicesMode {
+		GlobalObject.RouterSlicesMode = config.RouterSlicesMode
 	}
 
 	// logger
@@ -81,7 +87,4 @@ func UserConfToGlobal(config *Config) {
 		GlobalObject.WsPort = config.WsPort
 	}
 
-	if config.RouterSlicesMode {
-		GlobalObject.RouterSlicesMode = config.RouterSlicesMode
-	}
 }

--- a/zconf/userconf.go
+++ b/zconf/userconf.go
@@ -35,8 +35,8 @@ func UserConfToGlobal(config *Config) {
 	if config.MaxWorkerTaskLen != 0 {
 		GlobalObject.MaxWorkerTaskLen = config.MaxWorkerTaskLen
 	}
-	if config.WorkerGoroutineNums > 0 {
-		GlobalObject.WorkerGoroutineNums = config.WorkerGoroutineNums
+	if config.WorkerPoolGoroutineNums > 0 {
+		GlobalObject.WorkerPoolGoroutineNums = config.WorkerPoolGoroutineNums
 	}
 	if config.MaxMsgChanLen != 0 {
 		GlobalObject.MaxMsgChanLen = config.MaxMsgChanLen

--- a/znet/msghandler.go
+++ b/znet/msghandler.go
@@ -208,7 +208,7 @@ func (mh *MsgHandle) StartOneWorker(workerID int, taskQueue chan ziface.IRequest
 	// Continuously wait for messages in the queue
 	// (不断地等待队列中的消息)
 	//启动配置好的个数的协程去从消息池中取消息，多个协程可以避免因为单个阻塞的任务导致协程等待影响后面任务的执行
-	for i := uint32(0); i < zconf.GlobalObject.WorkerGoroutineNums; i++ {
+	for i := uint32(0); i < zconf.GlobalObject.WorkerPoolGoroutineNums; i++ {
 		go func() {
 			for {
 				select {

--- a/znet/msghandler.go
+++ b/znet/msghandler.go
@@ -207,28 +207,33 @@ func (mh *MsgHandle) StartOneWorker(workerID int, taskQueue chan ziface.IRequest
 	zlog.Ins().InfoF("Worker ID = %d is started.", workerID)
 	// Continuously wait for messages in the queue
 	// (不断地等待队列中的消息)
-	for {
-		select {
-		// If there is a message, take out the Request from the queue and execute the bound business method
-		// (有消息则取出队列的Request，并执行绑定的业务方法)
-		case request := <-taskQueue:
+	//启动配置好的个数的协程去从消息池中取消息，多个协程可以避免因为单个阻塞的任务导致协程等待影响后面任务的执行
+	for i := uint32(0); i < zconf.GlobalObject.WorkerGoroutineNums; i++ {
+		go func() {
+			for {
+				select {
+				// If there is a message, take out the Request from the queue and execute the bound business method
+				// (有消息则取出队列的Request，并执行绑定的业务方法)
+				case request := <-taskQueue:
 
-			switch req := request.(type) {
+					switch req := request.(type) {
 
-			case ziface.IFuncRequest:
-				// Internal function call request (内部函数调用request)
+					case ziface.IFuncRequest:
+						// Internal function call request (内部函数调用request)
 
-				mh.doFuncHandler(req, workerID)
+						mh.doFuncHandler(req, workerID)
 
-			case ziface.IRequest: // Client message request
+					case ziface.IRequest: // Client message request
 
-				if !zconf.GlobalObject.RouterSlicesMode {
-					mh.doMsgHandler(req, workerID)
-				} else if zconf.GlobalObject.RouterSlicesMode {
-					mh.doMsgHandlerSlices(req, workerID)
+						if !zconf.GlobalObject.RouterSlicesMode {
+							mh.doMsgHandler(req, workerID)
+						} else if zconf.GlobalObject.RouterSlicesMode {
+							mh.doMsgHandlerSlices(req, workerID)
+						}
+					}
 				}
 			}
-		}
+		}()
 	}
 }
 

--- a/znet/server.go
+++ b/znet/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aceld/zinx/zconf"
 	"github.com/aceld/zinx/zdecoder"
 	"github.com/aceld/zinx/zlog"
-	"github.com/aceld/zinx/zmetrics"
 	"github.com/gorilla/websocket"
 
 	"github.com/aceld/zinx/ziface"


### PR DESCRIPTION
1.可选配置化并发的去消息池读取消息处理。
2.调整了两个Zinx配置顺序到合适的位置。

第一点WorkerPoolGoroutineNums 是为了解决 如果有阻塞的任务在一个wokerPool中把当前执行的Goroutine阻塞了，由于go的gmp调度会将这个Goroutine放置，而当workerPool只有这一个Goroutine读取的时候，整个chan都会等待。如果配置了3个Goroutine去读取（默认配置是1，需要手动选取），即使一个阻塞，后续的任务也能被其他的Goroutine读取，除非少见的均是阻塞任务才会导致整个chan等待，同时配合wokerPoolSize可以做到wokerPool*WorkerPoolGoroutineNums的一个并发控制，可以做到更细粒度的控制并发数量。
但是需要注意在配置WorkerPoolGoroutineNums大于1时，那么同一消息队列的消息顺序将不可控！根据需求场景调整