### PR TITLE
[fix]: remove heartbeat handle msg

### DIFF
--- a/examples/zinx_heartbeat/client.go
+++ b/examples/zinx_heartbeat/client.go
@@ -34,7 +34,7 @@ func main() {
 	client := znet.NewClient("127.0.0.1", 8999)
 
 	// Start heartbeating detection. (启动心跳检测)
-	client.StartHeartBeatWithOption(3*time.Second, func(connection ziface.IConnection) {
+	client.StartHeartBeatWithCallback(3*time.Second, func(connection ziface.IConnection) {
 		fmt.Println("myClientOnRemoteNotAlive is Called, connID=", connection.GetConnID(), "remoteAddr = ", connection.RemoteAddr())
 		//关闭链接
 		connection.Stop()

--- a/examples/zinx_heartbeat/server.go
+++ b/examples/zinx_heartbeat/server.go
@@ -34,7 +34,7 @@ func main() {
 	s := znet.NewServer()
 
 	// Start heartbeating detection. (启动心跳检测)
-	s.StartHeartBeatWithOption(1*time.Second, func(connection ziface.IConnection) {
+	s.StartHeartBeatWithCallback(1*time.Second, func(connection ziface.IConnection) {
 		fmt.Println("myOnRemoteNotAlive is Called, connID=", connection.GetConnID(), "remoteAddr = ", connection.RemoteAddr())
 		//关闭链接
 		connection.Stop()

--- a/ziface/iclient.go
+++ b/ziface/iclient.go
@@ -44,8 +44,11 @@ type IClient interface {
 	// StartHeartBeat Start heartbeat detection(启动心跳检测)
 	StartHeartBeat(time.Duration)
 
-	// StartHeartBeatWithOption Start heartbeat detection with custom callbacks 启动心跳检测(自定义回调)
+	//Deprecated: StartHeartBeatWithOption Start heartbeat detection with custom callbacks 启动心跳检测(自定义回调)
 	StartHeartBeatWithOption(time.Duration, *HeartBeatOption)
+
+	//StartHeartBeatWithCallback Start heartbeat detection with custom callbacks 启动心跳检测(自定义回调)
+	StartHeartBeatWithCallback(time.Duration, OnRemoteNotAlive)
 
 	// GetLengthField Get the length field of this Client
 	GetLengthField() *LengthField

--- a/ziface/iclient.go
+++ b/ziface/iclient.go
@@ -44,8 +44,11 @@ type IClient interface {
 	// StartHeartBeat Start heartbeat detection(启动心跳检测)
 	StartHeartBeat(time.Duration)
 
-	// StartHeartBeatWithOption Start heartbeat detection with custom callbacks 启动心跳检测(自定义回调)
+	//Deprecated: StartHeartBeatWithOption Start heartbeat detection with custom callbacks 启动心跳检测(自定义回调)
 	StartHeartBeatWithOption(time.Duration, *HeartBeatOption)
+
+	// StartHeartBeatWithCallback Start heartbeat detection with custom callbacks 启动心跳检测(自定义回调)
+	StartHeartBeatWithCallback(time.Duration, OnRemoteNotAlive)
 
 	// GetLengthField Get the length field of this Client
 	GetLengthField() *LengthField

--- a/ziface/iheartbeat.go
+++ b/ziface/iheartbeat.go
@@ -2,17 +2,25 @@ package ziface
 
 type IHeartbeatChecker interface {
 	SetOnRemoteNotAlive(OnRemoteNotAlive)
+	//Deprecated: Heartbeat 在业务层添加对应的路由即可
 	SetHeartbeatMsgFunc(HeartBeatMsgFunc)
+	//Deprecated: Heartbeat 在业务层添加对应的路由即可
 	SetHeartbeatFunc(HeartBeatFunc)
+	//Deprecated: Heartbeat 在业务层添加对应的路由即可
 	BindRouter(uint32, IRouter)
+	//Deprecated: Heartbeat 在业务层添加对应的路由即可
 	BindRouterSlices(uint32, ...RouterHandler)
 	Start()
 	Stop()
+	//Deprecated: Heartbeat 在业务层处理相关的逻辑即可
 	SendHeartBeatMsg() error
 	BindConn(IConnection)
 	Clone() IHeartbeatChecker
+	//Deprecated: Heartbeat 在业务层添加对应的路由即可
 	MsgID() uint32
+	//Deprecated: Heartbeat 在业务层添加对应的路由即可
 	Router() IRouter
+	//Deprecated: Heartbeat 在业务层添加对应的路由即可
 	RouterSlices() []RouterHandler
 }
 
@@ -28,6 +36,7 @@ type HeartBeatFunc func(IConnection) error
 // 用户自定义的远程连接不存活时的处理方法
 type OnRemoteNotAlive func(IConnection)
 
+// Deprecated: Heartbeat 在业务层处理相关的逻辑
 type HeartBeatOption struct {
 	MakeMsg          HeartBeatMsgFunc // User-defined method for handling heartbeat detection messages(用户自定义的心跳检测消息处理方法)
 	OnRemoteNotAlive OnRemoteNotAlive // User-defined method for handling remote connections that are not alive(用户自定义的远程连接不存活时的处理方法)

--- a/ziface/iserver.go
+++ b/ziface/iserver.go
@@ -61,9 +61,13 @@ type IServer interface {
 	// (启动心跳检测)
 	StartHeartBeat(time.Duration)
 
+	//Deprecated: Start the heartbeat check (custom callback)
+	// 启动心跳检测(自定义回调)
+	StartHeartBeatWithOption(time.Duration, *HeartBeatOption)
+
 	// Start the heartbeat check (custom callback)
 	// 启动心跳检测(自定义回调)
-	StartHeartBeatWithOption(time.Duration, OnRemoteNotAlive)
+	StartHeartBeatWithCallback(time.Duration, OnRemoteNotAlive)
 
 	// Get the heartbeat checker
 	// (获取心跳检测器)

--- a/znet/client.go
+++ b/znet/client.go
@@ -204,13 +204,26 @@ func (c *Client) Start() {
 func (c *Client) StartHeartBeat(interval time.Duration) {
 	checker := NewHeartbeatChecker(interval)
 
-	// Add the heartbeat checker's route to the client's message handler.
-	// (添加心跳检测的路由)
-	c.AddRouter(checker.MsgID(), checker.Router())
-
 	// Bind the heartbeat checker to the client's connection.
 	// (client绑定心跳检测器)
 	c.hc = checker
+}
+
+// StartHeartBeatWithCallback starts heartbeat detection with a custom callback function.
+// interval: the time interval between each heartbeat message.
+// alive: a callback function that is called when the remote server is not alive.
+// 启动心跳检测(自定义回调)
+func (c *Client) StartHeartBeatWithCallback(interval time.Duration, alive ziface.OnRemoteNotAlive) {
+	// Create a new heartbeat checker with the given interval.
+	checker := NewHeartbeatChecker(interval)
+
+	// Set the heartbeat checker's callback function and message ID based on the HeartBeatOption struct.
+	if alive != nil {
+		checker.SetOnRemoteNotAlive(alive)
+	}
+	// Bind the heartbeat checker to the client's connection.
+	c.hc = checker
+
 }
 
 // StartHeartBeatWithOption starts heartbeat detection with a custom callback function.

--- a/znet/heartbeat.go
+++ b/znet/heartbeat.go
@@ -125,7 +125,6 @@ func (h *HeartbeatChecker) Stop() {
 }
 
 func (h *HeartbeatChecker) SendHeartBeatMsg() error {
-
 	msg := h.makeMsg(h.conn)
 
 	err := h.conn.SendMsg(h.msgID, msg)
@@ -148,8 +147,6 @@ func (h *HeartbeatChecker) check() (err error) {
 	} else {
 		if h.beatFunc != nil {
 			err = h.beatFunc(h.conn)
-		} else {
-			err = h.SendHeartBeatMsg()
 		}
 	}
 


### PR DESCRIPTION
### 更改原因：
1. `heartbeat` 模块 `check` 函数会被所有消息触发，所以不应该去处理消息并返回`heartbeat response` 给客户端
2.  心跳处理交给`IRouter` 去注册处理，`heartbeat` 不关心跳如何处理