### PR TITLE
note: go.1.16+ //go:build comment without // +build comment error. ne…

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -93,7 +93,7 @@ Zinx框架的项目制作采用编码和学习教程同步进行，将开发的�
 [<Zinx的Tcp调试工具>](https://github.com/xxl6097/tcptest)
 
 **版本**
-Golang 1.16+
+Golang 1.17+
 
 DownLoad zinx Source
 
@@ -101,7 +101,7 @@ DownLoad zinx Source
 $go get github.com/aceld/zinx
 ```
 
-> note: Golang Version 1.16+
+> note: Golang Version 1.17+
 
 #### Zinx-Server
 ```go

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ DownLoad zinx Source
 $go get github.com/aceld/zinx
 ```
 
-> note: Golang Version 1.16+
+> note: Golang Version 1.17+
 
 #### Zinx-Server
 ```go

--- a/znet/server.go
+++ b/znet/server.go
@@ -228,7 +228,7 @@ func (s *Server) ListenTcpConn() {
 			// (阻塞等待客户端建立连接请求)
 			conn, err := listener.Accept()
 			if err != nil {
-				//Go 1.16+
+				//Go 1.17+
 				if errors.Is(err, net.ErrClosed) {
 					zlog.Ins().ErrorF("Listener closed")
 					return


### PR DESCRIPTION
node zinx kcp need go 1.17+