### PR TITLE
使用ctx.Done代替isClose

### DIFF
--- a/znet/connection.go
+++ b/znet/connection.go
@@ -299,7 +299,10 @@ func (c *Connection) Start() {
 // Stop stops the connection and ends the current connection state.
 // (停止连接，结束当前连接状态)
 func (c *Connection) Stop() {
-	c.cancel()
+	if c.cancel != nil {
+		c.cancel()
+	}
+
 }
 
 func (c *Connection) GetConnection() net.Conn {
@@ -336,6 +339,9 @@ func (c *Connection) LocalAddr() net.Addr {
 }
 
 func (c *Connection) Send(data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("Send error data = %+v, ctx is done")
@@ -352,6 +358,9 @@ func (c *Connection) Send(data []byte) error {
 }
 
 func (c *Connection) SendToQueue(data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("Connection closed when send buff msg")
@@ -379,6 +388,9 @@ func (c *Connection) SendToQueue(data []byte) error {
 // SendMsg directly sends Message data to the remote TCP client.
 // (直接将Message数据发送数据给远程的TCP客户端)
 func (c *Connection) SendMsg(msgID uint32, data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("connection closed when send msg")
@@ -402,6 +414,9 @@ func (c *Connection) SendMsg(msgID uint32, data []byte) error {
 }
 
 func (c *Connection) SendBuffMsg(msgID uint32, data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("connection closed when send buff msg")
@@ -499,6 +514,9 @@ func (c *Connection) callOnConnStop() {
 }
 
 func (c *Connection) IsAlive() bool {
+	if c.ctx == nil {
+		return false
+	}
 	select {
 	case <-c.ctx.Done():
 		return false

--- a/znet/kcp_connection.go
+++ b/znet/kcp_connection.go
@@ -297,7 +297,10 @@ func (c *KcpConnection) Start() {
 // Stop stops the connection and ends the current connection state.
 // (停止连接，结束当前连接状态)
 func (c *KcpConnection) Stop() {
-	c.cancel()
+	if c.cancel != nil {
+		c.cancel()
+	}
+
 }
 
 func (c *KcpConnection) GetConnection() net.Conn {
@@ -334,6 +337,9 @@ func (c *KcpConnection) LocalAddr() net.Addr {
 }
 
 func (c *KcpConnection) Send(data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("connection closed when send msg")
@@ -350,6 +356,9 @@ func (c *KcpConnection) Send(data []byte) error {
 }
 
 func (c *KcpConnection) SendToQueue(data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("Connection closed when send buff msg")
@@ -378,6 +387,9 @@ func (c *KcpConnection) SendToQueue(data []byte) error {
 // SendMsg directly sends Message data to the remote KCP client.
 // (直接将Message数据发送数据给远程的KCP客户端)
 func (c *KcpConnection) SendMsg(msgID uint32, data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("Connection closed when send buff msg")
@@ -400,6 +412,9 @@ func (c *KcpConnection) SendMsg(msgID uint32, data []byte) error {
 }
 
 func (c *KcpConnection) SendBuffMsg(msgID uint32, data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("Connection closed when send buff msg")

--- a/znet/ws_connection.go
+++ b/znet/ws_connection.go
@@ -286,7 +286,10 @@ func (c *WsConnection) Start() {
 // Stop stops the connection and ends its current state.
 // (停止连接，结束当前连接状态)
 func (c *WsConnection) Stop() {
-	c.cancel()
+	if c.cancel != nil {
+		c.cancel()
+	}
+
 }
 
 func (c *WsConnection) GetConnection() net.Conn {
@@ -323,6 +326,9 @@ func (c *WsConnection) LocalAddr() net.Addr {
 }
 
 func (c *WsConnection) Send(data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("WsConnection closed when send msg")
@@ -339,6 +345,9 @@ func (c *WsConnection) Send(data []byte) error {
 }
 
 func (c *WsConnection) SendToQueue(data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("WsConnection closed when send msg")
@@ -367,6 +376,9 @@ func (c *WsConnection) SendToQueue(data []byte) error {
 // SendMsg directly sends the Message data to the remote TCP client.
 // (直接将Message数据发送数据给远程的TCP客户端)
 func (c *WsConnection) SendMsg(msgID uint32, data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("WsConnection closed when send msg")
@@ -393,6 +405,9 @@ func (c *WsConnection) SendMsg(msgID uint32, data []byte) error {
 
 // SendBuffMsg sends BuffMsg
 func (c *WsConnection) SendBuffMsg(msgID uint32, data []byte) error {
+	if c.ctx == nil {
+		return errors.New("connection not start when send msg")
+	}
 	select {
 	case <-c.ctx.Done():
 		return errors.New("WsConnection closed when send msg")
@@ -499,6 +514,9 @@ func (c *WsConnection) callOnConnStop() {
 }
 
 func (c *WsConnection) IsAlive() bool {
+	if c.ctx == nil {
+		return false
+	}
 	select {
 	case <-c.ctx.Done():
 		return false


### PR DESCRIPTION
1.可以减少锁的使用
2.可以避免消息量大时消息包被丢弃

# 减少不必要的成员变量。