### PR TITLE
解决connection模块写时，出现往空的channel写的panic错误

### DIFF
--- a/znet/connection.go
+++ b/znet/connection.go
@@ -507,11 +507,6 @@ func (c *Connection) finalizer() {
 		c.connManager.Remove(c)
 	}
 
-	// Close all channels associated with the connection
-	if c.msgBuffChan != nil {
-		close(c.msgBuffChan)
-	}
-
 	zlog.Ins().InfoF("Conn Stop()...ConnID = %d", c.connID)
 }
 
@@ -568,15 +563,9 @@ func (c *Connection) isClosed() bool {
 }
 
 func (c *Connection) setClose() bool {
-	if atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
-		return true
-	}
-	return false
+	return atomic.CompareAndSwapInt32(&c.closed, 0, 1)
 }
 
 func (c *Connection) setStartWriterFlag() bool {
-	if atomic.CompareAndSwapInt32(&c.startWriterFlag, 0, 1) {
-		return true
-	}
-	return false
+	return atomic.CompareAndSwapInt32(&c.startWriterFlag, 0, 1)
 }


### PR DESCRIPTION
为了不使用锁，此处去掉主动关闭close(c.msgBuffChan) 让系统自动GC 该channel。可避免写数据时出现竞争：往关闭的channel写数据的panic错误