### PR TITLE
增加kcp-go的 fec配置

### DIFF
--- a/examples/zinx_kcp/server.go
+++ b/examples/zinx_kcp/server.go
@@ -68,14 +68,16 @@ func Err() error {
 
 func main() {
 	s := znet.NewUserConfServer(&zconf.Config{
-		Mode:          "kcp",
-		KcpPort:       7777,
-		KcpRecvWindow: 128,
-		KcpSendWindow: 128,
-		KcpStreamMode: true,
-		KcpACKNoDelay: false,
-		LogDir:        "./",
-		LogFile:       "test.log",
+		Mode:               "kcp",
+		KcpPort:            7777,
+		KcpRecvWindow:      128,
+		KcpSendWindow:      128,
+		KcpStreamMode:      true,
+		KcpACKNoDelay:      false,
+		LogDir:             "./",
+		LogFile:            "test.log",
+		KcpFecDataShards:   10, //代表每10个原始数据块 发3个校验数据块
+		KcpFecParityShards: 3,
 	})
 	s.AddRouter(1, &TestRouter{})
 	s.SetOnConnStart(func(conn ziface.IConnection) {

--- a/zconf/globalobj.go
+++ b/zconf/globalobj.go
@@ -46,14 +46,16 @@ type Config struct {
 	/*
 		ServerConfig
 	*/
-	KcpACKNoDelay bool // changes ack flush option, set true to flush ack immediately,
-	KcpStreamMode bool // toggles the stream mode on/off
-	KcpNoDelay    int  // Whether nodelay mode is enabled, 0 is not enabled; 1 enabled.
-	KcpInterval   int  // Protocol internal work interval, in milliseconds, such as 10 ms or 20 ms.
-	KcpResend     int  // Fast retransmission mode, 0 represents off by default, 2 can be set (2 ACK spans will result in direct retransmission)
-	KcpNc         int  // Whether to turn off flow control, 0 represents “Do not turn off” by default, 1 represents “Turn off”.
-	KcpSendWindow int  // SND_BUF, this unit is the packet, default 32.
-	KcpRecvWindow int  // RCV_BUF, this unit is the packet, default 32.
+	KcpACKNoDelay      bool // changes ack flush option, set true to flush ack immediately,
+	KcpStreamMode      bool // toggles the stream mode on/off
+	KcpNoDelay         int  // Whether nodelay mode is enabled, 0 is not enabled; 1 enabled.
+	KcpInterval        int  // Protocol internal work interval, in milliseconds, such as 10 ms or 20 ms.
+	KcpResend          int  // Fast retransmission mode, 0 represents off by default, 2 can be set (2 ACK spans will result in direct retransmission)
+	KcpNc              int  // Whether to turn off flow control, 0 represents “Do not turn off” by default, 1 represents “Turn off”.
+	KcpSendWindow      int  // SND_BUF, this unit is the packet, default 32.
+	KcpRecvWindow      int  // RCV_BUF, this unit is the packet, default 32.
+	KcpFecDataShards   int  // The number of data shards in the FEC.(FEC数据分片), default 0.
+	KcpFecParityShards int  // The number of parity shards in the FEC.(FEC校验分片) default 0.
 
 	/*
 		Zinx
@@ -233,12 +235,14 @@ func init() {
 		KcpStreamMode:     true,
 		//Normal Mode: ikcp_nodelay(kcp, 0, 40, 0, 0);
 		//Turbo Mode： ikcp_nodelay(kcp, 1, 10, 2, 1);
-		KcpNoDelay:    1,
-		KcpInterval:   10,
-		KcpResend:     2,
-		KcpNc:         1,
-		KcpRecvWindow: 32,
-		KcpSendWindow: 32,
+		KcpNoDelay:         1,
+		KcpInterval:        10,
+		KcpResend:          2,
+		KcpNc:              1,
+		KcpRecvWindow:      32,
+		KcpSendWindow:      32,
+		KcpFecDataShards:   0,
+		KcpFecParityShards: 0,
 	}
 
 	// Note: Load some user-configured parameters from the configuration file.

--- a/zconf/userconf.go
+++ b/zconf/userconf.go
@@ -129,4 +129,12 @@ func UserConfToGlobal(config *Config) {
 		GlobalObject.KcpRecvWindow = config.KcpRecvWindow
 	}
 
+	if config.KcpFecDataShards != 0 {
+		GlobalObject.KcpFecDataShards = config.KcpFecDataShards
+	}
+
+	if config.KcpFecParityShards != 0 {
+		GlobalObject.KcpFecParityShards = config.KcpFecParityShards
+	}
+
 }

--- a/znet/server.go
+++ b/znet/server.go
@@ -112,6 +112,12 @@ type KcpConfig struct {
 	// RCV_BUF, this unit is the packet, default 32.
 	// (RCV_BUF接收缓冲区大小，单位是包，默认是32)
 	KcpRecvWindow int
+	// FEC data shards, default 0.
+	// (FEC数据分片,用于前向纠错比例配制) 默认是0
+	KcpFecDataShards int
+	// FEC parity shards, default 0.
+	// (FEC校验分片,用于前向纠错比例配制) 默认是0
+	KcpFecParityShards int
 }
 
 // newServerWithConfig creates a server handle based on config
@@ -142,14 +148,16 @@ func newServerWithConfig(config *zconf.Config, ipVersion string, opts ...Option)
 			},
 		},
 		kcpConfig: &KcpConfig{
-			KcpACKNoDelay: config.KcpACKNoDelay,
-			KcpStreamMode: config.KcpStreamMode,
-			KcpNoDelay:    config.KcpNoDelay,
-			KcpInterval:   config.KcpInterval,
-			KcpResend:     config.KcpResend,
-			KcpNc:         config.KcpNc,
-			KcpSendWindow: config.KcpSendWindow,
-			KcpRecvWindow: config.KcpRecvWindow,
+			KcpACKNoDelay:      config.KcpACKNoDelay,
+			KcpStreamMode:      config.KcpStreamMode,
+			KcpNoDelay:         config.KcpNoDelay,
+			KcpInterval:        config.KcpInterval,
+			KcpResend:          config.KcpResend,
+			KcpNc:              config.KcpNc,
+			KcpSendWindow:      config.KcpSendWindow,
+			KcpRecvWindow:      config.KcpRecvWindow,
+			KcpFecDataShards:   config.KcpFecDataShards,
+			KcpFecParityShards: config.KcpFecParityShards,
 		},
 	}
 
@@ -352,7 +360,7 @@ func (s *Server) ListenWebsocketConn() {
 func (s *Server) ListenKcpConn() {
 
 	// 1. Listen to the server address
-	listener, err := kcp.Listen(fmt.Sprintf("%s:%d", s.IP, s.KcpPort))
+	listener, err := kcp.ListenWithOptions(fmt.Sprintf("%s:%d", s.IP, s.KcpPort), nil, s.kcpConfig.KcpFecDataShards, s.kcpConfig.KcpFecParityShards)
 	if err != nil {
 		zlog.Ins().ErrorF("[START] resolve KCP addr err: %v\n", err)
 		return


### PR DESCRIPTION
虽然kcp对丢包超时等情况做了大量优化，
但是在一些实时较高的场景（比如游戏）还是难以接受。此时fec就可以和kcp一起使用，利用fec的纠错机制进一步减少重传

相关阅读:

https://vearne.cc/archives/39331
https://github.com/xtaci/kcp-go/blob/master/fec_test.go
https://github.com/wangyu-/UDPspeeder/blob/branch_libev/doc/README.zh-cn.md

https://segmentfault.com/a/1190000041690310