### PR TITLE
connection isClose 方法判断,防止 c.ctx 不存在导致程序 panic

### DIFF
--- a/znet/connection.go
+++ b/znet/connection.go
@@ -544,8 +544,9 @@ func (c *Connection) GetMsgHandler() ziface.IMsgHandle {
 }
 
 func (c *Connection) isClosed() bool {
-	return c.ctx.Err() != nil
+	return c.ctx == nil || c.ctx.Err() != nil
 }
+
 
 func (c *Connection) setStartWriterFlag() bool {
 	return atomic.CompareAndSwapInt32(&c.startWriterFlag, 0, 1)


### PR DESCRIPTION
connection isClose 方法判断,防止 c.ctx 不存在导致程序 panic