### PR TITLE
feat: 扩展websocket鉴权与wsConn的关联

### DIFF
--- a/ziface/iclient.go
+++ b/ziface/iclient.go
@@ -4,7 +4,10 @@
 
 package ziface
 
-import "time"
+import (
+	"net/url"
+	"time"
+)
 
 type IClient interface {
 	Restart()
@@ -66,4 +69,8 @@ type IClient interface {
 	// Get the name of this Client
 	// 获取客户端Client名称
 	GetName() string
+
+	SetUrl(url *url.URL)
+
+	GetUrl() *url.URL
 }

--- a/znet/client.go
+++ b/znet/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/aceld/zinx/zconf"
@@ -21,6 +22,7 @@ type Client struct {
 	Ip string
 	// Port of the target server to connect 目标链接服务器的端口
 	Port int
+	Url  *url.URL // 扩展，连接时带上其他参数
 	// Client version tcp,websocket,客户端版本 tcp,websocket
 	version string
 	// Connection instance 链接实例
@@ -126,6 +128,9 @@ func (c *Client) Restart() {
 		switch c.version {
 		case "websocket":
 			wsAddr := fmt.Sprintf("ws://%s:%d", c.Ip, c.Port)
+			if c.Url != nil {
+				wsAddr = c.Url.String()
+			}
 
 			// Create a raw socket and get net.Conn (创建原始Socket，得到net.Conn)
 			wsConn, _, err := c.dialer.Dial(wsAddr, nil)
@@ -303,4 +308,12 @@ func (c *Client) SetName(name string) {
 
 func (c *Client) GetName() string {
 	return c.Name
+}
+
+func (c *Client) SetUrl(url *url.URL) {
+	c.Url = url
+}
+
+func (c *Client) GetUrl() *url.URL {
+	return c.Url
 }

--- a/znet/options.go
+++ b/znet/options.go
@@ -1,6 +1,9 @@
 package znet
 
-import "github.com/aceld/zinx/ziface"
+import (
+	"github.com/aceld/zinx/ziface"
+	"net/url"
+)
 
 // Options for Server
 // (Server的服务Option)
@@ -30,5 +33,11 @@ func WithPacketClient(pack ziface.IDataPack) ClientOption {
 func WithNameClient(name string) ClientOption {
 	return func(c ziface.IClient) {
 		c.SetName(name)
+	}
+}
+
+func WithUrl(url *url.URL) ClientOption {
+	return func(c ziface.IClient) {
+		c.SetUrl(url)
 	}
 }

--- a/znet/options.go
+++ b/znet/options.go
@@ -1,8 +1,9 @@
 package znet
 
 import (
-	"github.com/aceld/zinx/ziface"
 	"net/url"
+
+	"github.com/aceld/zinx/ziface"
 )
 
 // Options for Server

--- a/znet/server.go
+++ b/znet/server.go
@@ -349,7 +349,7 @@ func (s *Server) ListenWebsocketConn() {
 		// 5. Handle the business logic of the new connection, which should already be bound to a handler and conn
 		// 5. 处理该新连接请求的 业务 方法， 此时应该有 handler 和 conn是绑定的
 		newCid := atomic.AddUint64(&s.cID, 1)
-		wsConn := newWebsocketConn(s, conn, newCid)
+		wsConn := newWebsocketConn(s, conn, newCid, r)
 		go s.StartConn(wsConn)
 
 	})

--- a/znet/ws_connection.go
+++ b/znet/ws_connection.go
@@ -18,6 +18,9 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// WsConnectionHttpReqCtxKey http请求上下文key
+type WsConnectionHttpReqCtxKey struct{}
+
 // WsConnection is a module for handling the read and write operations of a WebSocket connection.
 // (Websocket连接模块, 用于处理 Websocket 连接的读写业务 一个连接对应一个Connection)
 type WsConnection struct {
@@ -116,7 +119,7 @@ type WsConnection struct {
 func newWebsocketConn(server ziface.IServer, conn *websocket.Conn, connID uint64, r *http.Request) ziface.IConnection {
 	// Initialize Conn properties (初始化Conn属性)
 	c := &WsConnection{
-		ctx:         context.WithValue(context.Background(), "http.request.context", r.Context()), // websocketAuth可以在上下文中传递特殊的参数或信息;比如鉴权后，设置一些用户信息或房间id
+		ctx:         context.WithValue(context.Background(), WsConnectionHttpReqCtxKey{}, r.Context()), // websocketAuth可以在上下文中传递特殊的参数或信息;比如鉴权后，设置一些用户信息或房间id
 		conn:        conn,
 		connID:      connID,
 		connIdStr:   strconv.FormatUint(connID, 10),


### PR DESCRIPTION
使用http request context传递一些鉴权后设置的信息
客户端支持连接指定地址及参数

实现客户端连接服务端的第一个请求开始验证token,验证成功后，可以设置一些可信任的参数到上下文中，后续连接触发SetOnConnect方法中可以从上下文中读取并设置到属性中，后续连接都可以读取使用。