### PR TITLE
Fix CodeQL: Actions Job or Workflow does not set permissions

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,10 @@
 name: reviewdog
 on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/aceld/zinx/security/code-scanning/2
