### PR TITLE
Feature: SendBuffMsg api with timeout

### DIFF
--- a/examples/zinx_tls/server/server.go
+++ b/examples/zinx_tls/server/server.go
@@ -7,13 +7,14 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"math/big"
+	"os"
+	"time"
+
 	"github.com/aceld/zinx/zconf"
 	"github.com/aceld/zinx/ziface"
 	"github.com/aceld/zinx/zlog"
 	"github.com/aceld/zinx/znet"
-	"math/big"
-	"os"
-	"time"
 )
 
 // PingRouter ping test 自定义路由
@@ -27,7 +28,7 @@ func (this *PingRouter) Handle(request ziface.IRequest) {
 	zlog.Debug("Call PingRouter Handle")
 	zlog.Debug("recv from client : msgId=", request.GetMsgID(), ", data=", string(request.GetData()))
 
-	err := request.GetConnection().SendBuffMsg(2, []byte("Pong with TLS"))
+	err := request.GetConnection().SendBuffMsg(2, []byte("Pong with TLS"), ziface.WithSendMsgTimeout(time.Millisecond*10))
 	if err != nil {
 		zlog.Error(err)
 	}

--- a/ziface/iconnection.go
+++ b/ziface/iconnection.go
@@ -37,8 +37,8 @@ type IConnection interface {
 	LocalAddrString() string    // Get the local address information of the connection as a string
 	RemoteAddrString() string   // Get the remote address information of the connection as a string
 
-	Send(data []byte) error        // Send data directly to the remote TCP client (without buffering)
-	SendToQueue(data []byte) error // Send data to the message queue to be sent to the remote TCP client later
+	Send(data []byte) error                               // Send data directly to the remote TCP client (without buffering)
+	SendToQueue(data []byte, opts ...MsgSendOption) error // Send data to the message queue to be sent to the remote TCP client later
 
 	// Send Message data directly to the remote TCP client (without buffering)
 	// 直接将Message数据发送数据给远程的TCP客户端(无缓冲)
@@ -46,7 +46,7 @@ type IConnection interface {
 
 	// Send Message data to the message queue to be sent to the remote TCP client later (with buffering)
 	// 直接将Message数据发送给远程的TCP客户端(有缓冲)
-	SendBuffMsg(msgID uint32, data []byte) error
+	SendBuffMsg(msgID uint32, data []byte, opts ...MsgSendOption) error
 
 	SetProperty(key string, value interface{})   // Set connection property
 	GetProperty(key string) (interface{}, error) // Get connection property

--- a/ziface/options.go
+++ b/ziface/options.go
@@ -1,0 +1,15 @@
+package ziface
+
+import "time"
+
+type MsgSendOptionObj struct {
+	Timeout time.Duration
+}
+
+type MsgSendOption func(opt *MsgSendOptionObj)
+
+func WithSendMsgTimeout(timeout time.Duration) MsgSendOption {
+	return func(opt *MsgSendOptionObj) {
+		opt.Timeout = timeout
+	}
+}

--- a/znet/kcp_connection.go
+++ b/znet/kcp_connection.go
@@ -364,7 +364,7 @@ func (c *KcpConnection) Send(data []byte) error {
 	return nil
 }
 
-func (c *KcpConnection) SendToQueue(data []byte) error {
+func (c *KcpConnection) SendToQueue(data []byte, opts ...ziface.MsgSendOption) error {
 	c.msgLock.RLock()
 	defer c.msgLock.RUnlock()
 
@@ -377,7 +377,15 @@ func (c *KcpConnection) SendToQueue(data []byte) error {
 		go c.StartWriter()
 	}
 
-	idleTimeout := time.NewTimer(5 * time.Millisecond)
+	opt := ziface.MsgSendOptionObj{
+		Timeout: 5 * time.Millisecond,
+	}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	idleTimeout := time.NewTimer(opt.Timeout)
 	defer idleTimeout.Stop()
 
 	if c.isClosed() {
@@ -420,7 +428,7 @@ func (c *KcpConnection) SendMsg(msgID uint32, data []byte) error {
 	return nil
 }
 
-func (c *KcpConnection) SendBuffMsg(msgID uint32, data []byte) error {
+func (c *KcpConnection) SendBuffMsg(msgID uint32, data []byte, opts ...ziface.MsgSendOption) error {
 	if c.isClosed() {
 		return errors.New("connection closed when send buff msg")
 	}
@@ -433,7 +441,15 @@ func (c *KcpConnection) SendBuffMsg(msgID uint32, data []byte) error {
 		go c.StartWriter()
 	}
 
-	idleTimeout := time.NewTimer(5 * time.Millisecond)
+	opt := ziface.MsgSendOptionObj{
+		Timeout: 5 * time.Millisecond,
+	}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	idleTimeout := time.NewTimer(opt.Timeout)
 	defer idleTimeout.Stop()
 
 	msg, err := c.packet.Pack(zpack.NewMsgPackage(msgID, data))

--- a/znet/ws_connection.go
+++ b/znet/ws_connection.go
@@ -362,7 +362,7 @@ func (c *WsConnection) Send(data []byte) error {
 	return nil
 }
 
-func (c *WsConnection) SendToQueue(data []byte) error {
+func (c *WsConnection) SendToQueue(data []byte, opts ...ziface.MsgSendOption) error {
 	c.msgLock.Lock()
 	defer c.msgLock.Unlock()
 
@@ -375,7 +375,15 @@ func (c *WsConnection) SendToQueue(data []byte) error {
 		go c.StartWriter()
 	}
 
-	idleTimeout := time.NewTimer(5 * time.Millisecond)
+	opt := ziface.MsgSendOptionObj{
+		Timeout: 5 * time.Millisecond,
+	}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	idleTimeout := time.NewTimer(opt.Timeout)
 	defer idleTimeout.Stop()
 
 	if c.isClosed == true {
@@ -423,7 +431,7 @@ func (c *WsConnection) SendMsg(msgID uint32, data []byte) error {
 }
 
 // SendBuffMsg sends BuffMsg
-func (c *WsConnection) SendBuffMsg(msgID uint32, data []byte) error {
+func (c *WsConnection) SendBuffMsg(msgID uint32, data []byte, opts ...ziface.MsgSendOption) error {
 	c.msgLock.Lock()
 	defer c.msgLock.Unlock()
 
@@ -436,7 +444,15 @@ func (c *WsConnection) SendBuffMsg(msgID uint32, data []byte) error {
 		go c.StartWriter()
 	}
 
-	idleTimeout := time.NewTimer(5 * time.Millisecond)
+	opt := ziface.MsgSendOptionObj{
+		Timeout: 5 * time.Millisecond,
+	}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	idleTimeout := time.NewTimer(opt.Timeout)
 	defer idleTimeout.Stop()
 
 	if c.isClosed == true {


### PR DESCRIPTION
SendBuffMsg(msgID uint32, data []byte) 接口默认是五毫秒超时，有时在大流量的情况下或者网络质量波动的情况下，可能可以忍受10毫秒或更久才返回超时错误。所以把接口改成：SendBuffMsg(msgID uint32, data []byte, opts ...MsgSendOption), 可以指定自定义的超时时间， 同时兼容业务代码使用SendBuffMsg接口。使用时可以参考例子examples/zinx_tls/server/server.go