### PR TITLE
fix:修复重复调用client.Restart()导致协程泄漏的问题;修复重复调用client.Stop() panic的问题

### DIFF
--- a/ziface/iclient.go
+++ b/ziface/iclient.go
@@ -61,7 +61,7 @@ type IClient interface {
 	AddInterceptor(IInterceptor)
 
 	// Get the error channel for this Client 获取客户端错误管道
-	GetErrChan() chan error
+	GetErrChan() <-chan error
 
 	// Set the name of this Clien
 	// 设置客户端Client名称

--- a/znet/client.go
+++ b/znet/client.go
@@ -354,7 +354,7 @@ func (c *Client) GetLengthField() *ziface.LengthField {
 	return nil
 }
 
-func (c *Client) GetErrChan() chan error {
+func (c *Client) GetErrChan() <-chan error {
 	return c.errChan
 }
 

--- a/znet/client.go
+++ b/znet/client.go
@@ -141,10 +141,10 @@ func (c *Client) Restart() {
 		return
 	}
 	c.started = true
-	c.Unlock()
-
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	c.Add(1)
+	c.Unlock()
+
 	zlog.Ins().InfoF("[START] Zinx Client dial RemoteAddr: %s:%d\n", c.Ip, c.Port)
 	go func() {
 		defer c.Done()


### PR DESCRIPTION
Fixes #385
#### 1.客户端重启可能导致协程泄漏的问题
    2025-9-03，客户端在重启过程中可能会有协程泄漏的问题，特别是重复调用client.Restart()或者忘记调用client.Stop(), 以致没有关闭c.exitChan. 导致协程没有退出。同时也有可能导致底层网络连接没有关闭。

```go
func (c *Client) Restart() {
    .....
    .....
    func() {
        .......

		select {
		case <-c.exitChan:
			zlog.Ins().InfoF("client exit.")
		}
    }()
}
```
#### 2.重复调用client.Stop() 会panic的问题。

```go
func (c *Client) Stop() {
	con := c.Conn()
	if con != nil {
		zlog.Ins().InfoF("[STOP] Zinx Client LocalAddr: %s, RemoteAddr: %s\n", con.LocalAddr(), con.RemoteAddr())
		con.Stop()
	}
	c.exitChan <- struct{}{}
	close(c.exitChan)
	close(c.ErrChan)
}
```
重复调用client.Stop()的话, 第二次调用client.Stop()会往exitChan这个已经closed的channel 写入数据，导致panic

### 处理方法：
1. 允许重复调用client.Restart(), 每次重启时会内部会调用client.Stop() 停掉目前正在运行的后台协程，同时会关闭底层网络连接，保证一个client只要一个后台协程在运行。
2. 允许重复调用client.Stop(), 内部判断client是否处于运行状态，只有真正运行才做实际操作，比如关闭底层网络连接等。
3. 增加context, 用来取消后台协程的运行，和控制底层网络连接dial的生命周期。