### PR TITLE
fix

### DIFF
--- a/examples/zinx_conn_property_check/README.md
+++ b/examples/zinx_conn_property_check/README.md
@@ -1,0 +1,103 @@
+# Zinx Connection Property Check Example
+
+This example demonstrates how to implement client connection property validation in Zinx framework.
+
+## Overview
+
+The server checks if the client has set a valid `name` property with value `test` when the connection is established.
+If the property is missing or has an invalid value, the server disconnects the client immediately.
+
+## Files
+
+- `server/server.go`: Server implementation with connection property validation
+- `client/client.go`: Client implementation with valid connection property
+- `client/client_invalid.go`: Client implementation with invalid connection property
+
+## How to Run
+
+### 1. Start the Server
+
+```bash
+cd server
+go run server.go
+```
+
+The server will start listening on `127.0.0.1:8999`.
+
+### 2. Run the Valid Client
+
+In a new terminal:
+
+```bash
+cd client
+go run client.go
+```
+
+This client sets the `name` property to `test` (which is valid), so the connection will be accepted by the server.
+
+### 3. Run the Invalid Client
+
+In another terminal:
+
+```bash
+cd client
+go run client_invalid.go
+```
+
+This client sets the `name` property to `invalid_name` (which is invalid), so the server will disconnect it immediately.
+
+## Expected Output
+
+### Server Output
+
+When valid client connects:
+```
+[INFO] 2023/10/05 14:30:00 Server starting
+[INFO] 2023/10/05 14:30:05 Server connection started
+[INFO] 2023/10/05 14:30:05 Client connected with valid name: test
+[DEBUG] 2023/10/05 14:30:05 Call PingRouter Handle
+[DEBUG] 2023/10/05 14:30:05 recv from client : msgId=1, data=Hello server, I'm client with valid name
+```
+
+When invalid client connects:
+```
+[INFO] 2023/10/05 14:30:10 Server connection started
+[ERROR] 2023/10/05 14:30:10 Invalid client name: invalid_name
+[INFO] 2023/10/05 14:30:10 Server connection lost
+```
+
+### Valid Client Output
+
+```
+[INFO] 2023/10/05 14:30:05 Client starting
+[INFO] 2023/10/05 14:30:05 Client connected to server
+[DEBUG] 2023/10/05 14:30:05 Call PingRouter Handle
+[DEBUG] 2023/10/05 14:30:05 recv from server : msgId=2, data=pong-server
+```
+
+### Invalid Client Output
+
+```
+[INFO] 2023/10/05 14:30:10 Client (with invalid name) starting
+[INFO] 2023/10/05 14:30:10 Client connected to server
+[INFO] 2023/10/05 14:30:10 Client disconnected from server (expected, since we used invalid name)
+```
+
+## Implementation Details
+
+### Server Side
+
+1. Set a connection start callback function using `s.SetOnConnStart(DoConnectionBegin)`
+2. In the callback function:
+   - Get the `name` property from the connection using `conn.GetProperty("name")`
+   - Check if the property exists and has the value `test`
+   - If validation fails, disconnect the client using `conn.Stop()`
+
+### Client Side
+
+1. Set a connection start callback function using `client.SetOnConnStart(DoClientConnectedBegin)`
+2. In the callback function:
+   - Set the `name` property using `conn.SetProperty("name", "test")` (for valid client)
+   - Set an invalid name for the invalid client
+
+This example shows how to use Zinx's built-in connection property mechanism to implement client validation without modifying the framework's core code.

--- a/examples/zinx_conn_property_check/client/client.go
+++ b/examples/zinx_conn_property_check/client/client.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/zlog"
+	"github.com/aceld/zinx/znet"
+)
+
+// DoClientConnectedBegin is the callback function when client connects to server
+// DoClientConnectedBegin 是客户端连接到服务器时的回调函数
+func DoClientConnectedBegin(conn ziface.IConnection) {
+	zlog.Debug("Client connected to server")
+
+	// Set connection properties / 设置连接属性
+	// Set name to "test" which is required by server / 设置name为服务器要求的"test"
+	conn.SetProperty("name", "test")
+
+	// Set additional connection properties / 设置额外的连接属性
+	conn.SetProperty("version", "1.0")
+	conn.SetProperty("user_id", 12345)
+
+	// Send a test message to server / 向服务器发送测试消息
+	if err := conn.SendMsg(1, []byte("Hello server, I'm client with valid name and properties")); err != nil {
+		zlog.Error(err)
+	}
+}
+
+// DoClientConnectedLost is the callback function when client disconnects from server
+// DoClientConnectedLost 是客户端与服务器断开连接时的回调函数
+func DoClientConnectedLost(conn ziface.IConnection) {
+	zlog.Debug("Client disconnected from server")
+	os.Exit(0)
+}
+
+// PingRouter ping test 自定义路由
+type PingRouter struct {
+	znet.BaseRouter
+}
+
+// Ping Handle
+func (this *PingRouter) Handle(request ziface.IRequest) {
+	zlog.Debug("Call PingRouter Handle")
+	// Read the data from the server
+	zlog.Debug("recv from server : msgId=", request.GetMsgID(), ", data=", string(request.GetData()))
+}
+
+func main() {
+	// Create client / 创建客户端
+	client := znet.NewClient("127.0.0.1", 8999)
+
+	// Set connection start and stop callbacks / 设置连接开始和断开的回调
+	client.SetOnConnStart(DoClientConnectedBegin)
+	client.SetOnConnStop(DoClientConnectedLost)
+
+	// Add router / 添加路由
+	client.AddRouter(2, &PingRouter{})
+
+	// Start client / 启动客户端
+	zlog.Debug("Client starting")
+	client.Start()
+
+	// Wait for interrupt signal to exit / 等待中断信号以退出
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	<-ch
+
+	// Stop client / 停止客户端
+	client.Stop()
+}

--- a/examples/zinx_conn_property_check/client/client_invalid.go
+++ b/examples/zinx_conn_property_check/client/client_invalid.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/zlog"
+	"github.com/aceld/zinx/znet"
+)
+
+// DoClientConnectedBegin is the callback function when client connects to server
+// DoClientConnectedBegin 是客户端连接到服务器时的回调函数
+func DoClientConnectedBegin(conn ziface.IConnection) {
+	zlog.Debug("Client connected to server")
+
+	// Set connection properties with invalid name / 设置带有无效名称的连接属性
+	conn.SetProperty("name", "invalid_name")
+
+	// Try to send a test message to server / 尝试向服务器发送测试消息
+	// This message may not be sent because the server may have already disconnected us / 此消息可能无法发送，因为服务器可能已经断开了我们的连接
+	if err := conn.SendMsg(1, []byte("Hello server, I'm client with invalid name")); err != nil {
+		zlog.Error(err)
+	}
+}
+
+// DoClientConnectedLost is the callback function when client disconnects from server
+// DoClientConnectedLost 是客户端与服务器断开连接时的回调函数
+func DoClientConnectedLost(conn ziface.IConnection) {
+	zlog.Debug("Client disconnected from server (expected, since we used invalid name)")
+	os.Exit(0)
+}
+
+func main() {
+	// Create client / 创建客户端
+	client := znet.NewClient("127.0.0.1", 8999)
+
+	// Set connection start and stop callbacks / 设置连接开始和断开的回调
+	client.SetOnConnStart(DoClientConnectedBegin)
+	client.SetOnConnStop(DoClientConnectedLost)
+
+	// Start client / 启动客户端
+	zlog.Debug("Client (with invalid name) starting")
+	client.Start()
+
+	// Wait for interrupt signal to exit / 等待中断信号以退出
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+
+	// Wait for a short time to see if we get disconnected by server / 等待一段时间，看看是否会被服务器断开连接
+	select {
+	case <-ch:
+		// Stop client / 停止客户端
+		client.Stop()
+	case <-time.After(5 * time.Second):
+		zlog.Warn("Client is still connected, which is unexpected")
+		client.Stop()
+		os.Exit(1)
+	}
+}

--- a/examples/zinx_conn_property_check/server/server.go
+++ b/examples/zinx_conn_property_check/server/server.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/zlog"
+	"github.com/aceld/zinx/znet"
+)
+
+// DoConnectionBegin is the callback function when connection starts
+// DoConnectionBegin 是连接开始时的回调函数
+func DoConnectionBegin(conn ziface.IConnection) {
+	zlog.Debug("Server connection started")
+
+	// Check client connection properties / 检查客户端连接属性
+	name, err := conn.GetProperty("name")
+	if err != nil {
+		zlog.Error("Failed to get client name property: ", err)
+		// Disconnect if property not found / 如果属性不存在则断开连接
+		conn.Stop()
+		return
+	}
+
+	// Verify if name is "test" / 验证name是否为"test"
+	if name != "test" {
+		zlog.Error("Invalid client name: ", name)
+		// Disconnect if name is not valid / 如果name无效则断开连接
+		conn.Stop()
+		return
+	}
+
+	zlog.Debug("Client connected with valid name: ", name)
+
+	// Get additional connection properties / 获取额外的连接属性
+	version, err := conn.GetProperty("version")
+	if err != nil {
+		zlog.Debug("Client version property not set")
+	} else {
+		zlog.Debug("Client version: ", version)
+	}
+
+	userID, err := conn.GetProperty("user_id")
+	if err != nil {
+		zlog.Debug("Client user_id property not set")
+	} else {
+		zlog.Debug("Client user_id: ", userID)
+	}
+}
+
+// DoConnectionLost is the callback function when connection is lost
+// DoConnectionLost 是连接断开时的回调函数
+func DoConnectionLost(conn ziface.IConnection) {
+	zlog.Debug("Server connection lost")
+}
+
+// PingRouter ping test 自定义路由
+type PingRouter struct {
+	znet.BaseRouter
+}
+
+// Ping Handle
+func (this *PingRouter) Handle(request ziface.IRequest) {
+	zlog.Debug("Call PingRouter Handle")
+	// Read the data from the client first, then send back "ping...ping...ping"
+	zlog.Debug("recv from client : msgId=", request.GetMsgID(), ", data=", string(request.GetData()))
+
+	err := request.GetConnection().SendMsg(2, []byte("pong-server"))
+	if err != nil {
+		zlog.Error(err)
+	}
+}
+
+func main() {
+	// Create server / 创建服务器
+	s := znet.NewServer()
+
+	// Set connection start and stop callbacks / 设置连接开始和断开的回调
+	s.SetOnConnStart(DoConnectionBegin)
+	s.SetOnConnStop(DoConnectionLost)
+
+	// Add router / 添加路由
+	s.AddRouter(1, &PingRouter{})
+
+	// Start server / 启动服务器
+	zlog.Debug("Server starting")
+	s.Serve()
+}


### PR DESCRIPTION
在当前实现基础上， 实现一个功能，客户端使用tcp方式连接服务器后，服务器需要校验客户端携带的连接属性参数，是否是内置的name=test，如果不是则断开连接。尽量使用框架已实现的逻辑完成这个功能。然后在 examples目录下给出可运行的demo。