### PR TITLE
fix: prevent exitChan blocking in websocket mode

### DIFF
--- a/znet/server.go
+++ b/znet/server.go
@@ -463,7 +463,6 @@ func (s *Server) Stop() {
 	// Clear other connection information or other information that needs to be cleaned up
 	// (将其他需要清理的连接信息或者其他信息 也要一并停止或者清理)
 	s.ConnMgr.ClearConn()
-	s.exitChan <- struct{}{}
 	close(s.exitChan)
 }
 


### PR DESCRIPTION
通过退出信号试图停止进程,发现一直阻塞到超时.
关闭的 channel 会立即让所有阻塞的 <-ch 操作返回零值. t.exitChan <- struct{}{} 是多余的.

如果只启动websocket模式:
没有 goroutine 在执行 <-s.exitChan
s.exitChan <- struct{}{} 永久阻塞