### PR TITLE
Potential fix for code scanning alert no. 5: Disabled TLS certificate check

### DIFF
--- a/znet/client.go
+++ b/znet/client.go
@@ -174,11 +174,8 @@ func (c *Client) Restart() {
 			var err error
 			if c.useTLS {
 				// TLS encryption
-				config := &tls.Config{
-					// Skip certificate verification here because the CA certificate of the certificate issuer is not authenticated
-					// (这里是跳过证书验证，因为证书签发机构的CA证书是不被认证的)
-					InsecureSkipVerify: true,
-				}
+				// Use default TLS verification (certificate chain + hostname verification enabled).
+				config := &tls.Config{}
 				d := &tls.Dialer{
 					Config: config,
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/aceld/zinx/security/code-scanning/5](https://github.com/aceld/zinx/security/code-scanning/5)

To fix this without changing overall functionality (TLS connection still used via `tls.Dialer`), remove the insecure override and rely on Go’s default verification behavior.

**Best fix in this snippet:**
- In `znet/client.go`, inside `Client.Restart()` where `c.useTLS` is handled, replace the `tls.Config` initialization that sets `InsecureSkipVerify: true` with an empty/default TLS config (`&tls.Config{}`).
- Keep the existing dialer flow unchanged (`tls.Dialer` + `DialContext`), so behavior remains the same except certificate/hostname checks are now enforced.

No new methods or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
