### PR TITLE
fix(client): keep decode/router order without worker pool

### DIFF
--- a/znet/msghandler.go
+++ b/znet/msghandler.go
@@ -47,6 +47,7 @@ type MsgHandle struct {
 	// (责任链构造器)
 	builder      *chainBuilder
 	RouterSlices *RouterSlices
+	clientMode   bool
 }
 
 // newMsgHandle creates MsgHandle
@@ -84,11 +85,11 @@ func newMsgHandle() *MsgHandle {
 	}
 
 	handle := &MsgHandle{
-		Apis:         make(map[uint32]ziface.IRouter),
-		RouterSlices: NewRouterSlices(),
-		freeWorkers:  freeWorkers,
-		builder:      newChainBuilder(),
-		// 可额外临时分配的workerID集合
+		Apis:             make(map[uint32]ziface.IRouter),
+		RouterSlices:     NewRouterSlices(),
+		freeWorkers:      freeWorkers,
+		builder:          newChainBuilder(),
+		clientMode:       false,
 		extraFreeWorkers: extraFreeWorkers,
 	}
 
@@ -142,6 +143,7 @@ func newCliMsgHandle() *MsgHandle {
 		RouterSlices: NewRouterSlices(),
 		freeWorkers:  freeWorkers,
 		builder:      newChainBuilder(),
+		clientMode:   true,
 		// 可额外临时分配的workerID集合
 		extraFreeWorkers: extraFreeWorkers,
 	}
@@ -266,10 +268,19 @@ func (mh *MsgHandle) Intercept(chain ziface.IChain) ziface.IcResp {
 
 				// Execute the corresponding Handle method from the bound message and its corresponding processing method
 				// (从绑定好的消息和对应的处理方法中执行对应的Handle方法)
-				if !zconf.GlobalObject.RouterSlicesMode {
-					go mh.doMsgHandler(iRequest, WorkerIDWithoutWorkerPool)
-				} else if zconf.GlobalObject.RouterSlicesMode {
-					go mh.doMsgHandlerSlices(iRequest, WorkerIDWithoutWorkerPool)
+				if mh.clientMode {
+					// Client mode requires decode->router order consistency when worker pool is disabled.
+					if !zconf.GlobalObject.RouterSlicesMode {
+						mh.doMsgHandler(iRequest, WorkerIDWithoutWorkerPool)
+					} else if zconf.GlobalObject.RouterSlicesMode {
+						mh.doMsgHandlerSlices(iRequest, WorkerIDWithoutWorkerPool)
+					}
+				} else {
+					if !zconf.GlobalObject.RouterSlicesMode {
+						go mh.doMsgHandler(iRequest, WorkerIDWithoutWorkerPool)
+					} else if zconf.GlobalObject.RouterSlicesMode {
+						go mh.doMsgHandlerSlices(iRequest, WorkerIDWithoutWorkerPool)
+					}
 				}
 
 			}

--- a/znet/msghandler_client_order_test.go
+++ b/znet/msghandler_client_order_test.go
@@ -1,0 +1,100 @@
+package znet
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aceld/zinx/ziface"
+	"github.com/aceld/zinx/zpack"
+)
+
+type orderRouter struct {
+	BaseRouter
+	id    int
+	delay time.Duration
+	mu    *sync.Mutex
+	out   *[]int
+	done  chan struct{}
+}
+
+func (r *orderRouter) Handle(req ziface.IRequest) {
+	if r.delay > 0 {
+		time.Sleep(r.delay)
+	}
+	r.mu.Lock()
+	*r.out = append(*r.out, r.id)
+	if len(*r.out) == 2 {
+		close(r.done)
+	}
+	r.mu.Unlock()
+}
+
+func TestClientMsgHandleNoWorkerPoolPreservesOrder(t *testing.T) {
+	mh := newCliMsgHandle()
+
+	var mu sync.Mutex
+	got := make([]int, 0, 2)
+	done := make(chan struct{})
+
+	mh.AddRouter(1, &orderRouter{id: 1, delay: 120 * time.Millisecond, mu: &mu, out: &got, done: done})
+	mh.AddRouter(2, &orderRouter{id: 2, delay: 0, mu: &mu, out: &got, done: done})
+
+	req1 := NewRequest(nil, zpack.NewMessageByMsgId(1, 0, nil))
+	req2 := NewRequest(nil, zpack.NewMessageByMsgId(2, 0, nil))
+
+	start := time.Now()
+	mh.Execute(req1)
+	mh.Execute(req2)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for client handlers to complete")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 handled messages, got %d", len(got))
+	}
+	if got[0] != 1 || got[1] != 2 {
+		t.Fatalf("expected client order [1 2], got %v", got)
+	}
+	if elapsed := time.Since(start); elapsed < 120*time.Millisecond {
+		t.Fatalf("expected serialized execution in client mode, elapsed=%v", elapsed)
+	}
+}
+
+func TestServerMsgHandleNoWorkerPoolRemainsAsync(t *testing.T) {
+	mh := newMsgHandle()
+	mh.WorkerPoolSize = 0
+
+	var mu sync.Mutex
+	got := make([]int, 0, 2)
+	done := make(chan struct{})
+
+	mh.AddRouter(1, &orderRouter{id: 1, delay: 120 * time.Millisecond, mu: &mu, out: &got, done: done})
+	mh.AddRouter(2, &orderRouter{id: 2, delay: 0, mu: &mu, out: &got, done: done})
+
+	req1 := NewRequest(nil, zpack.NewMessageByMsgId(1, 0, nil))
+	req2 := NewRequest(nil, zpack.NewMessageByMsgId(2, 0, nil))
+
+	mh.Execute(req1)
+	mh.Execute(req2)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for server handlers to complete")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 handled messages, got %d", len(got))
+	}
+	if got[0] != 2 || got[1] != 1 {
+		t.Fatalf("expected async server order [2 1], got %v", got)
+	}
+}


### PR DESCRIPTION

问题现象
在客户端模式（`newCliMsgHandle`）中，`WorkerPoolSize` 被设置为 `0`。
`MsgHandle.Intercept` 在 worker pool 关闭时使用了：
- `go mh.doMsgHandler(...)`
- `go mh.doMsgHandlerSlices(...)`

上述异步分发会打破单连接消息串行语义。如果第一条消息处理较慢，后续消息可能先进入路由，从而出现“解码顺序 != 路由处理顺序”。

根因分析
无 worker pool 的处理路径在所有模式下都使用异步 goroutine 分发；但客户端业务通常期望单连接严格有序处理，二者语义不一致。

修改内容
1) 为 `MsgHandle` 增加 `clientMode` 标记：
- `newMsgHandle()`（服务端）：`clientMode=false`
- `newCliMsgHandle()`（客户端）：`clientMode=true`

2) 调整 `MsgHandle.Intercept` 在无 worker pool 分支的行为：
- 客户端模式：改为同步执行路由，保证顺序
  - `mh.doMsgHandler(...)` / `mh.doMsgHandlerSlices(...)`
- 服务端模式：保持原有异步 goroutine 行为（兼容历史语义）
  - `go mh.doMsgHandler(...)` / `go mh.doMsgHandlerSlices(...)`

3) 增加回归测试：
- `TestClientMsgHandleNoWorkerPoolPreservesOrder`
  - 验证客户端模式下顺序保持为 [1,2]
- `TestServerMsgHandleNoWorkerPoolRemainsAsync`
  - 验证服务端无 worker pool 仍保持异步行为（延迟首条后顺序为 [2,1]）

涉及文件
- `znet/msghandler.go`
- `znet/msghandler_client_order_test.go`（新增）

修复后行为
- 客户端模式 + 自定义解码器 + 无 worker pool：
  - 路由执行顺序与解码输出顺序一致（单连接内）。
- 服务端无 worker pool 路径：
  - 维持异步行为，不改变既有兼容性。

测试方式
1) 运行定向回归测试：
`go -C /home/calelin/dev/zinx test ./znet -run 'TestClientMsgHandleNoWorkerPoolPreservesOrder|TestServerMsgHandleNoWorkerPoolRemainsAsync' -count=1`

2) 重复运行客户端顺序测试，验证稳定性：
`go -C /home/calelin/dev/zinx test ./znet -run TestClientMsgHandleNoWorkerPoolPreservesOrder -count=10`

本地验证结果
1) 定向回归测试输出：
`ok  	github.com/aceld/zinx/znet	0.244s`

2) 重复顺序测试输出：
`ok  	github.com/aceld/zinx/znet	1.207s`
